### PR TITLE
Issue/42/restore demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # RAIL: Redshift Assessment Infrastructure Layers
 
 RAIL is a flexible software library providing tools to produce at-scale photometric redshift data products, including uncertainties and summary statistics, and stress-test them under realistically complex systematics.
-A detailed description of RAIL's modular structure is available in the [Overview](https://lsstdescrail.readthedocs.io/en/stable/source/overview.html) on ReadTheDocs.
+A detailed description of RAIL's modular structure is available in the [Overview](https://rail-hub.readthedocs.io/en/stable/source/overview.html) on ReadTheDocs.
 
 RAIL serves as the infrastructure supporting many extragalactic applications of the Legacy Survey of Space and Time (LSST) on the Vera C. Rubin Observatory, including Rubin-wide commissioning activities. 
 RAIL was initiated by the Photometric Redshifts (PZ) Working Group (WG) of the LSST Dark Energy Science Collaboration (DESC) as a result of the lessons learned from the [Data Challenge 1 (DC1) experiment](https://academic.oup.com/mnras/article/499/2/1587/5905416) to enable the PZ WG Deliverables in [the LSST-DESC Science Roadmap (see Sec. 5.18)](https://lsstdesc.org/assets/pdf/docs/DESC_SRM_latest.pdf), aiming to guide the selection and implementation of redshift estimators in DESC analysis pipelines.
@@ -16,11 +16,11 @@ RAIL is developed and maintained by a diverse team comprising DESC Pipeline Scie
 
 ## Installation
 
-Installation instructions are available under [Installation](https://lsstdescrail.readthedocs.io/en/stable/source/installation.html) on ReadTheDocs.
+Installation instructions are available under [Installation](https://rail-hub.readthedocs.io/en/stable/source/installation.html) on ReadTheDocs.
 
 ## Contributing
 
-The greatest strength of RAIL is its extensibility; those interested in contributing to RAIL should start by consulting the [Contributing guidelines](https://lsstdescrail.readthedocs.io/en/stable/source/contributing.html) on ReadTheDocs.
+The greatest strength of RAIL is its extensibility; those interested in contributing to RAIL should start by consulting the [Contributing guidelines](https://rail-hub.readthedocs.io/en/stable/source/contributing.html) on ReadTheDocs.
 
 ## Citing RAIL
 
@@ -28,4 +28,4 @@ RAIL is open source and may be used according to the terms of its [LICENSE](http
 If you make use of the ideas or software here in any publication, you must cite this repository <https://github.com/LSSTDESC/RAIL> as "LSST-DESC PZ WG (in prep)" with the [Zenodo DOI](https://doi.org/10.5281/zenodo.7017551).
 Please consider also inviting the developers as co-authors on publications resulting from your use of RAIL by [making an issue](https://github.com/LSSTDESC/rail/issues/new/choose).
 Additionally, several of the codes accessible through the RAIL ecosystem must be cited if used in a publication.
-A convenient list of what to cite may be found under [Citing RAIL](https://lsstdescrail.readthedocs.io/en/stable/source/citing.html) on ReadTheDocs.
+A convenient list of what to cite may be found under [Citing RAIL](https://rail-hub.readthedocs.io/en/stable/source/citing.html) on ReadTheDocs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,8 +41,8 @@ The RAIL source code is publically available at https://github.com/LSSTDESC/RAIL
    :maxdepth: 1
    :caption: Usage Demos
 
-   Core Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/core_notebooks.html>
-   Creation Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/creation_notebooks.html>
-   Estimation Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/estimation_notebooks.html>
-   Evaluation Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/evaluation_notebooks.html>
-   Goldenspike <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/goldenspike.html>
+   Core Notebooks <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/core_notebooks.html>
+   Creation Notebooks <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/creation_notebooks.html>
+   Estimation Notebooks <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/estimation_notebooks.html>
+   Evaluation Notebooks <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/evaluation_notebooks.html>
+   Goldenspike <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/goldenspike.html>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,12 +33,16 @@ The RAIL source code is publically available at https://github.com/LSSTDESC/RAIL
 
 .. toctree::
    :maxdepth: 1
-   :caption: Usage Demos
-
-   demos
-
-.. toctree::
-   :maxdepth: 1
    :caption: API
 
    api
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Usage Demos
+
+   Core Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/core_notebooks.html>
+   Creation Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/creation_notebooks.html>
+   Estimation Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/estimation_notebooks.html>
+   Evaluation Notebooks <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/evaluation_notebooks.html>
+   Goldenspike <https://rail-external-html-rtd.readthedocs.io/projects/rail-notebooks/en/latest/goldenspike.html>

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,6 +1,6 @@
-************
-Overview
-************
+**********************
+Contribution Overview
+**********************
 
 RAIL is a constellation of multiple packages developed publicly on GitHub and 
 welcomes all interested developers, regardless of DESC membership or LSST data rights.


### PR DESCRIPTION
## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- For #42
- Also fixes broken RTD links in gh readme and clarifies redundant header in contribution docs.


## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
Adds links to a new, separate repository which automates building all notebooks in the RAIL notebooks folders and stores the rendered outputs as .rst files for easy readthedocs integration.

**Note**: Notebook repository is [here](https://github.com/OliviaLynn/rail_notebooks) (currently a personal repo, happy to transfer ownership to LSSTDESC but unsure if there's an organization-specific process around that).


## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Documentation Change Checklist
- [x] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
