### PR TITLE
Lynn/quick doc fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,4 +45,4 @@ The RAIL source code is publically available at https://github.com/LSSTDESC/RAIL
    Creation Notebooks <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/creation_notebooks.html>
    Estimation Notebooks <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/estimation_notebooks.html>
    Evaluation Notebooks <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/evaluation_notebooks.html>
-   Goldenspike <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/goldenspike.html>
+   Goldenspike <https://rail-hub.readthedocs.io/projects/rail-notebooks/en/latest/goldenspike_notebook.html>

--- a/examples/estimation_examples/test_sampled_summarizers.ipynb
+++ b/examples/estimation_examples/test_sampled_summarizers.ipynb
@@ -5,7 +5,7 @@
    "id": "c697f8c4",
    "metadata": {},
    "source": [
-    "Test Sampled Summarizers\n",
+    "# Test Sampled Summarizers\n",
     "\n",
     "Author: Sam Schmidt\n",
     "\n",


### PR DESCRIPTION
Fixing a broken link and a markdown title I'd missed (both are breaking things on RTD)