### PR TITLE
Updated notebooks for new error model.

### DIFF
--- a/examples/core_examples/Pipe_Example.ipynb
+++ b/examples/core_examples/Pipe_Example.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "author: Eric Charles\n",
     "\n",
-    "last run successfully: April 26, 2023"
+    "last run successfully: August 2, 2023"
    ]
   },
   {
@@ -37,13 +37,13 @@
     "import ceci\n",
     "import rail\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.creation.degradation.spectroscopic_degraders import LineConfusion \n",
+    "from rail.creation.degradation.spectroscopic_degraders import LineConfusion\n",
     "from rail.creation.degradation.quantityCut import QuantityCut\n",
     "from rail.creation.degradation.lsst_error_model import LSSTErrorModel\n",
     "from rail.creation.engines.flowEngine import FlowCreator, FlowPosterior\n",
     "from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.core.utilStages import ColumnMapper, TableConverter"
+    "from rail.core.utilStages import ColumnMapper, TableConverter\n"
    ]
   },
   {
@@ -64,7 +64,7 @@
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
-    "DS.__class__.allow_overwrite = True"
+    "DS.__class__.allow_overwrite = True\n"
    ]
   },
   {
@@ -93,11 +93,14 @@
    "outputs": [],
    "source": [
     "from rail.core.utils import RAILDIR\n",
-    "flow_file = os.path.join(RAILDIR, 'rail/examples_data/goldenspike_data/data/pretrained_flow.pkl')\n",
-    "bands = ['u','g','r','i','z','y']\n",
-    "band_dict = {band:f'mag_{band}_lsst' for band in bands}\n",
-    "rename_dict = {f'mag_{band}_lsst_err':f'mag_err_{band}_lsst' for band in bands}\n",
-    "post_grid = [float(x) for x in np.linspace(0., 5, 21)]"
+    "\n",
+    "flow_file = os.path.join(\n",
+    "    RAILDIR, \"rail/examples_data/goldenspike_data/data/pretrained_flow.pkl\"\n",
+    ")\n",
+    "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
+    "band_dict = {band: f\"mag_{band}_lsst\" for band in bands}\n",
+    "rename_dict = {f\"mag_{band}_lsst_err\": f\"mag_err_{band}_lsst\" for band in bands}\n",
+    "post_grid = [float(x) for x in np.linspace(0.0, 5, 21)]\n"
    ]
   },
   {
@@ -126,21 +129,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow_engine_test = FlowCreator.make_stage(name='flow_engine_test', \n",
-    "                                         model=flow_file, n_samples=50)\n",
-    "      \n",
-    "lsst_error_model_test = LSSTErrorModel.make_stage(name='lsst_error_model_test',\n",
-    "                                                  bandNames=band_dict)\n",
-    "                \n",
-    "col_remapper_test = ColumnMapper.make_stage(name='col_remapper_test', hdf5_groupname='',\n",
-    "                                            columns=rename_dict)\n",
+    "flow_engine_test = FlowCreator.make_stage(\n",
+    "    name=\"flow_engine_test\", model=flow_file, n_samples=50\n",
+    ")\n",
     "\n",
-    "flow_post_test = FlowPosterior.make_stage(name='flow_post_test',\n",
-    "                                          column='redshift', flow=flow_file,\n",
-    "                                          grid=post_grid)\n",
+    "lsst_error_model_test = LSSTErrorModel.make_stage(\n",
+    "    name=\"lsst_error_model_test\", renameDict=band_dict\n",
+    ")\n",
     "\n",
-    "table_conv_test = TableConverter.make_stage(name='table_conv_test', output_format='numpyDict', \n",
-    "                                            seed=12345)\n"
+    "col_remapper_test = ColumnMapper.make_stage(\n",
+    "    name=\"col_remapper_test\", hdf5_groupname=\"\", columns=rename_dict\n",
+    ")\n",
+    "\n",
+    "flow_post_test = FlowPosterior.make_stage(\n",
+    "    name=\"flow_post_test\", column=\"redshift\", flow=flow_file, grid=post_grid\n",
+    ")\n",
+    "\n",
+    "table_conv_test = TableConverter.make_stage(\n",
+    "    name=\"table_conv_test\", output_format=\"numpyDict\", seed=12345\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow_engine_test.sample(6, seed=0).data\n"
    ]
   },
   {
@@ -161,7 +177,7 @@
     "pipe = ceci.Pipeline.interactive()\n",
     "stages = [flow_engine_test, lsst_error_model_test, col_remapper_test, table_conv_test]\n",
     "for stage in stages:\n",
-    "    pipe.add_stage(stage)"
+    "    pipe.add_stage(stage)\n"
    ]
   },
   {
@@ -180,7 +196,7 @@
    "outputs": [],
    "source": [
     "# Get the names of the stages\n",
-    "pipe.stage_names"
+    "pipe.stage_names\n"
    ]
   },
   {
@@ -190,7 +206,7 @@
    "outputs": [],
    "source": [
     "# Get the configuration of a particular stage\n",
-    "pipe.flow_engine_test.config"
+    "pipe.flow_engine_test.config\n"
    ]
   },
   {
@@ -199,9 +215,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the list of outputs 'tags' \n",
+    "# Get the list of outputs 'tags'\n",
     "# These are how the stage thinks of the outputs, as a list names associated to DataHandle types.\n",
-    "pipe.flow_engine_test.outputs"
+    "pipe.flow_engine_test.outputs\n"
    ]
   },
   {
@@ -212,7 +228,7 @@
    "source": [
     "# Get the list of outputs 'aliased tags'\n",
     "# These are how the pipeline things of the outputs, as a unique key that points to a particular file\n",
-    "pipe.flow_engine_test._outputs"
+    "pipe.flow_engine_test._outputs\n"
    ]
   },
   {
@@ -233,8 +249,8 @@
    "source": [
     "lsst_error_model_test.connect_input(flow_engine_test)\n",
     "col_remapper_test.connect_input(lsst_error_model_test)\n",
-    "#flow_post_test.connect_input(col_remapper_test, inputTag='input')\n",
-    "table_conv_test.connect_input(col_remapper_test)"
+    "# flow_post_test.connect_input(col_remapper_test, inputTag='input')\n",
+    "table_conv_test.connect_input(col_remapper_test)\n"
    ]
   },
   {
@@ -258,7 +274,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe.initialize(dict(model=flow_file), dict(output_dir='.', log_dir='.', resume=False), None)"
+    "pipe.initialize(\n",
+    "    dict(model=flow_file), dict(output_dir=\".\", log_dir=\".\", resume=False), None\n",
+    ")\n"
    ]
   },
   {
@@ -280,7 +298,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe.save('pipe_saved.yml')"
+    "pipe.save(\"pipe_saved.yml\")\n"
    ]
   },
   {
@@ -296,7 +314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr = ceci.Pipeline.read('pipe_saved.yml')"
+    "pr = ceci.Pipeline.read(\"pipe_saved.yml\")\n"
    ]
   },
   {
@@ -314,8 +332,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr.run()"
+    "pr.run()\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwd\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -334,7 +368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/examples/creation_examples/degradation-demo.ipynb
+++ b/examples/creation_examples/degradation-demo.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "author: John Franklin Crenshaw, Sam Schmidt, Eric Charles, others...\n",
     "\n",
-    "last run successfully: April 26, 2023\n",
+    "last run successfully: August 2, 2023\n",
     "\n",
     "This notebook demonstrates how to use a RAIL Engines to create galaxy samples, and how to use Degraders to add various errors and biases to the sample.\n",
     "\n",
@@ -46,7 +46,7 @@
     ")\n",
     "from rail.creation.degradation.lsst_error_model import LSSTErrorModel\n",
     "from rail.creation.degradation.quantityCut import QuantityCut\n",
-    "from rail.core.stage import RailStage"
+    "from rail.core.stage import RailStage\n"
    ]
   },
   {
@@ -64,7 +64,10 @@
    "source": [
     "import pzflow\n",
     "import os\n",
-    "flow_file = os.path.join(os.path.dirname(pzflow.__file__), 'example_files', 'example-flow.pzflow.pkl')"
+    "\n",
+    "flow_file = os.path.join(\n",
+    "    os.path.dirname(pzflow.__file__), \"example_files\", \"example-flow.pzflow.pkl\"\n",
+    ")\n"
    ]
   },
   {
@@ -81,7 +84,7 @@
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
-    "DS.__class__.allow_overwrite = True"
+    "DS.__class__.allow_overwrite = True\n"
    ]
   },
   {
@@ -104,7 +107,9 @@
    "outputs": [],
    "source": [
     "n_samples = int(1e5)\n",
-    "flowCreator_truth = FlowCreator.make_stage(name='truth', model=flow_file, n_samples=n_samples)"
+    "flowCreator_truth = FlowCreator.make_stage(\n",
+    "    name=\"truth\", model=flow_file, n_samples=n_samples\n",
+    ")\n"
    ]
   },
   {
@@ -120,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flowCreator_truth.get_data('model')"
+    "flowCreator_truth.get_data(\"model\")\n"
    ]
   },
   {
@@ -140,7 +145,7 @@
    "source": [
     "samples_truth = flowCreator_truth.sample(n_samples, seed=0)\n",
     "print(samples_truth())\n",
-    "print(\"Data was written to \", samples_truth.path)"
+    "print(\"Data was written to \", samples_truth.path)\n"
    ]
   },
   {
@@ -160,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "errorModel = LSSTErrorModel.make_stage(name='error_model')"
+    "errorModel = LSSTErrorModel.make_stage(name=\"error_model\")\n"
    ]
   },
   {
@@ -176,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "errorModel"
+    "errorModel\n"
    ]
   },
   {
@@ -193,15 +198,18 @@
    "outputs": [],
    "source": [
     "samples_w_errs = errorModel(samples_truth)\n",
-    "samples_w_errs()"
+    "samples_w_errs()\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice some of the magnitudes are NaN's. These are non-detections. This means those observed magnitudes were beyond the 30mag limit that is default in `LSSTErrorModel`. \n",
-    "You can change this limit and the corresponding flag by setting `magLim=...` and `ndFlag=...` in the constructor for `LSSTErrorModel`. \n",
+    "Notice some of the magnitudes are inf's.\n",
+    "These are non-detections.\n",
+    "This means those observed fluxes were negative. \n",
+    "You can change the limit for non-detections by setting `sigLim=...`, where the value you set is the minimum SNR.\n",
+    "Setting `ndFlag=...` changes the value used to flag non-detections.\n",
     "\n",
     "Let's plot the error as a function of magnitude"
    ]
@@ -215,20 +223,19 @@
     "fig, ax = plt.subplots(figsize=(5, 4), dpi=100)\n",
     "\n",
     "for band in \"ugrizy\":\n",
-    "    \n",
     "    # pull out the magnitudes and errors\n",
     "    mags = samples_w_errs.data[band].to_numpy()\n",
     "    errs = samples_w_errs.data[band + \"_err\"].to_numpy()\n",
-    "    \n",
+    "\n",
     "    # sort them by magnitude\n",
     "    mags, errs = mags[mags.argsort()], errs[mags.argsort()]\n",
-    "    \n",
+    "\n",
     "    # plot errs vs mags\n",
-    "    ax.plot(mags, errs, label=band) \n",
-    "    \n",
+    "    ax.plot(mags, errs, label=band)\n",
+    "\n",
     "ax.legend()\n",
     "ax.set(xlabel=\"Magnitude (AB)\", ylabel=\"Error (mags)\")\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -255,7 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gold_cut = QuantityCut.make_stage(name='cuts', cuts={\"i\": 25.3})                                "
+    "gold_cut = QuantityCut.make_stage(name=\"cuts\", cuts={\"i\": 25.3})\n"
    ]
   },
   {
@@ -271,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples_gold_w_errs = gold_cut(samples_w_errs)"
+    "samples_gold_w_errs = gold_cut(samples_w_errs)\n"
    ]
   },
   {
@@ -306,7 +313,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inv_incomplete = InvRedshiftIncompleteness.make_stage(name='incompleteness', pivot_redshift=0.8)"
+    "inv_incomplete = InvRedshiftIncompleteness.make_stage(\n",
+    "    name=\"incompleteness\", pivot_redshift=0.8\n",
+    ")\n"
    ]
   },
   {
@@ -315,7 +324,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples_incomplete_gold_w_errs = inv_incomplete(samples_gold_w_errs)"
+    "samples_incomplete_gold_w_errs = inv_incomplete(samples_gold_w_errs)\n"
    ]
   },
   {
@@ -345,10 +354,14 @@
     "\n",
     "ax.hist(samples_truth()[\"redshift\"], label=\"Truth\", **hist_settings)\n",
     "ax.hist(samples_gold_w_errs()[\"redshift\"], label=\"Gold\", **hist_settings)\n",
-    "ax.hist(samples_incomplete_gold_w_errs()[\"redshift\"], label=\"Incomplete Gold\", **hist_settings)\n",
+    "ax.hist(\n",
+    "    samples_incomplete_gold_w_errs()[\"redshift\"],\n",
+    "    label=\"Incomplete Gold\",\n",
+    "    **hist_settings\n",
+    ")\n",
     "ax.legend(title=\"Sample\")\n",
     "ax.set(xlim=(zmin, zmax), xlabel=\"Redshift\", ylabel=\"Galaxy density\")\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -380,10 +393,12 @@
     "OII = 3727\n",
     "OIII = 5007\n",
     "\n",
-    "lc_2p_0II_0III = LineConfusion.make_stage(name='lc_2p_0II_0III',\n",
-    "                                          true_wavelen=OII, wrong_wavelen=OIII, frac_wrong=0.02)\n",
-    "lc_1p_0III_0II = LineConfusion.make_stage(name='lc_1p_0III_0II',\n",
-    "                                          true_wavelen=OIII, wrong_wavelen=OII, frac_wrong=0.01)"
+    "lc_2p_0II_0III = LineConfusion.make_stage(\n",
+    "    name=\"lc_2p_0II_0III\", true_wavelen=OII, wrong_wavelen=OIII, frac_wrong=0.02\n",
+    ")\n",
+    "lc_1p_0III_0II = LineConfusion.make_stage(\n",
+    "    name=\"lc_1p_0III_0II\", true_wavelen=OIII, wrong_wavelen=OII, frac_wrong=0.01\n",
+    ")\n"
    ]
   },
   {
@@ -392,7 +407,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples_conf_inc_gold_w_errs = lc_1p_0III_0II(lc_2p_0II_0III(samples_incomplete_gold_w_errs))"
+    "samples_conf_inc_gold_w_errs = lc_1p_0III_0II(\n",
+    "    lc_2p_0II_0III(samples_incomplete_gold_w_errs)\n",
+    ")\n"
    ]
   },
   {
@@ -422,11 +439,19 @@
     "\n",
     "ax.hist(samples_truth()[\"redshift\"], label=\"Truth\", **hist_settings)\n",
     "ax.hist(samples_gold_w_errs()[\"redshift\"], label=\"Gold\", **hist_settings)\n",
-    "ax.hist(samples_incomplete_gold_w_errs()[\"redshift\"], label=\"Incomplete Gold\", **hist_settings)\n",
-    "ax.hist(samples_conf_inc_gold_w_errs()[\"redshift\"], label=\"Confused Incomplete Gold\", **hist_settings)\n",
+    "ax.hist(\n",
+    "    samples_incomplete_gold_w_errs()[\"redshift\"],\n",
+    "    label=\"Incomplete Gold\",\n",
+    "    **hist_settings\n",
+    ")\n",
+    "ax.hist(\n",
+    "    samples_conf_inc_gold_w_errs()[\"redshift\"],\n",
+    "    label=\"Confused Incomplete Gold\",\n",
+    "    **hist_settings\n",
+    ")\n",
     "ax.legend(title=\"Sample\")\n",
     "ax.set(xlim=(zmin, zmax), xlabel=\"Redshift\", ylabel=\"Galaxy density\")\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -446,15 +471,20 @@
    "source": [
     "fig, ax = plt.subplots(figsize=(6, 6), dpi=85)\n",
     "\n",
-    "ax.scatter(samples_incomplete_gold_w_errs()[\"redshift\"], samples_conf_inc_gold_w_errs()[\"redshift\"], \n",
-    "           marker=\".\", s=1)\n",
+    "ax.scatter(\n",
+    "    samples_incomplete_gold_w_errs()[\"redshift\"],\n",
+    "    samples_conf_inc_gold_w_errs()[\"redshift\"],\n",
+    "    marker=\".\",\n",
+    "    s=1,\n",
+    ")\n",
     "\n",
     "ax.set(\n",
-    "    xlim=(0, 2.5), ylim=(0, 2.5),\n",
+    "    xlim=(0, 2.5),\n",
+    "    ylim=(0, 2.5),\n",
     "    xlabel=\"True spec-z (in Incomplete Gold sample)\",\n",
     "    ylabel=\"Spec-z listed in the Confused sample\",\n",
     ")\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -463,6 +493,11 @@
    "source": [
     "Now we can clearly see the spec-z errors! The galaxies above the line y=x are the [OII] -> [OIII] galaxies, while the ones below are the [OIII] -> [OII] galaxies."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -481,7 +516,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/examples/creation_examples/photometric_realization_demo.ipynb
+++ b/examples/creation_examples/photometric_realization_demo.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "author: John Franklin Crenshaw, Sam Schmidt, Eric Charles, Ziang Yan\n",
     "\n",
-    "last run successfully: April 26, 2023"
+    "last run successfully: August 2, 2023"
    ]
   },
   {
@@ -28,7 +28,7 @@
     "from pzflow.examples import get_example_flow\n",
     "from rail.creation.engines.flowEngine import FlowCreator\n",
     "from rail.creation.degradation.lsst_error_model import LSSTErrorModel\n",
-    "from rail.core.stage import RailStage"
+    "from rail.core.stage import RailStage\n"
    ]
   },
   {
@@ -46,7 +46,10 @@
    "source": [
     "import pzflow\n",
     "import os\n",
-    "flow_file = os.path.join(os.path.dirname(pzflow.__file__), 'example_files', 'example-flow.pzflow.pkl')"
+    "\n",
+    "flow_file = os.path.join(\n",
+    "    os.path.dirname(pzflow.__file__), \"example_files\", \"example-flow.pzflow.pkl\"\n",
+    ")\n"
    ]
   },
   {
@@ -63,7 +66,7 @@
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
-    "DS.__class__.allow_overwrite = True"
+    "DS.__class__.allow_overwrite = True\n"
    ]
   },
   {
@@ -86,7 +89,9 @@
    "outputs": [],
    "source": [
     "n_samples = int(1e5)\n",
-    "flowEngine_truth = FlowCreator.make_stage(name='truth', model=flow_file, n_samples=n_samples)"
+    "flowEngine_truth = FlowCreator.make_stage(\n",
+    "    name=\"truth\", model=flow_file, n_samples=n_samples\n",
+    ")\n"
    ]
   },
   {
@@ -102,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flowEngine_truth.get_data('model')"
+    "flowEngine_truth.get_data(\"model\")\n"
    ]
   },
   {
@@ -131,12 +136,14 @@
     "\n",
     "import numpy as np\n",
     "\n",
-    "samples_truth.data['major'] = np.abs(np.random.normal(loc=0.01, scale=0.1, size=n_samples)) # add major and minor axes\n",
-    "b_to_a = 1 - 0.5*np.random.rand(n_samples)\n",
-    "samples_truth.data['minor'] = samples_truth.data['major'] * b_to_a \n",
+    "samples_truth.data[\"major\"] = np.abs(\n",
+    "    np.random.normal(loc=0.01, scale=0.1, size=n_samples)\n",
+    ")  # add major and minor axes\n",
+    "b_to_a = 1 - 0.5 * np.random.rand(n_samples)\n",
+    "samples_truth.data[\"minor\"] = samples_truth.data[\"major\"] * b_to_a\n",
     "\n",
     "print(samples_truth())\n",
-    "print(\"Data was written to \", samples_truth.path)"
+    "print(\"Data was written to \", samples_truth.path)\n"
    ]
   },
   {
@@ -159,23 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "errorModel = LSSTErrorModel.make_stage(name='error_model')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To see the details of the model, including the default settings we are using, you can just print the model:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "errorModel"
+    "errorModel = LSSTErrorModel.make_stage(name=\"error_model\")\n"
    ]
   },
   {
@@ -191,8 +182,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "errorModel_auto = LSSTErrorModel.make_stage(name='error_model_auto',\n",
-    "                                                errortype=\"auto\")"
+    "errorModel_auto = LSSTErrorModel.make_stage(\n",
+    "    name=\"error_model_auto\", extendedType=\"auto\"\n",
+    ")\n"
    ]
   },
   {
@@ -201,8 +193,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "errorModel_gaap = LSSTErrorModel.make_stage(name='error_model_gaap',\n",
-    "                                                errortype=\"gaap\")"
+    "errorModel_gaap = LSSTErrorModel.make_stage(\n",
+    "    name=\"error_model_gaap\", extendedType=\"gaap\"\n",
+    ")\n"
    ]
   },
   {
@@ -219,7 +212,7 @@
    "outputs": [],
    "source": [
     "samples_w_errs = errorModel(samples_truth)\n",
-    "samples_w_errs()"
+    "samples_w_errs()\n"
    ]
   },
   {
@@ -229,7 +222,7 @@
    "outputs": [],
    "source": [
     "samples_w_errs_gaap = errorModel_gaap(samples_truth)\n",
-    "samples_w_errs_gaap.data"
+    "samples_w_errs_gaap.data\n"
    ]
   },
   {
@@ -239,15 +232,17 @@
    "outputs": [],
    "source": [
     "samples_w_errs_auto = errorModel_auto(samples_truth)\n",
-    "samples_w_errs_auto.data"
+    "samples_w_errs_auto.data\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice some of the magnitudes are NaN's. These are non-detections. This means those observed magnitudes were beyond the 30mag limit that is default in `LSSTErrorModel`. \n",
-    "You can change this limit and the corresponding flag by setting `magLim=...` and `ndFlag=...` in the constructor for `LSSTErrorModel`. \n",
+    "Notice some of the magnitudes are inf's.\n",
+    "These are non-detections (i.e. the noisy flux was negative).\n",
+    "You can change the nSigma limit for non-detections by setting `sigLim=...`.\n",
+    "For example, if `sigLim=5`, then all fluxes with `SNR<5` are flagged as non-detections.\n",
     "\n",
     "Let's plot the error as a function of magnitude"
    ]
@@ -328,9 +323,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that the photometric error increases as magnitude gets dimmer, just like you would expect. Notice, however, that we have galaxies as dim as magnitude 30. This is because the Flow produces a sample much deeper than the LSST 5-sigma limiting magnitudes. There are no galaxies dimmer than magnitude 30 because LSSTErrorModel sets magnitudes > 30 equal to NaN (the default flag for non-detections).\n",
+    "You can see that the photometric error increases as magnitude gets dimmer, just like you would expect, and that the extended source errors are greater than the point source errors.\n",
+    "The extended source errors are also scattered, because the galaxies have random sizes.\n",
     "\n",
-    "Also, you can find the GAaP and AUTO magnitude error are scattered due to variable galaxy sizes. Also, you can find that there are gaps between GAAP magnitude error and point souce magnitude error, this is because the additional factors due to aperture sizes have a minimum value of $\\sqrt{(\\sigma^2+A_{\\mathrm{min}})/\\sigma^2}$, where $\\sigma$ is the width of the beam, $A_{\\min}$ is an offset of the aperture sizes (taken to be 0.7 arcmin here)."
+    "Also, you can find the GAaP and AUTO magnitude error are scattered due to variable galaxy sizes. Also, you can find that there are gaps between GAAP magnitude error and point souce magnitude error, this is because the additional factors due to aperture sizes have a minimum value of $\\sqrt{(\\sigma^2+A_{\\mathrm{min}})/\\sigma^2}$, where $\\sigma$ is the width of the beam, $A_{\\min}$ is an offset of the aperture sizes (taken to be 0.7 arcmin here).\n",
+    "\n",
+    "You can also see that there are *very* faint galaxies in this sample.\n",
+    "That's because, by default, the error model returns magnitudes for all positive fluxes.\n",
+    "If you want these galaxies flagged as non-detections instead, you can set e.g. `sigLim=5`, and everything with `SNR<5` will be flagged as a non-detection."
    ]
   }
  ],
@@ -353,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/creation_examples/posterior-demo.ipynb
+++ b/examples/creation_examples/posterior-demo.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "author: John Franklin Crenshaw, Sam Schmidt, Eric Charles, others...\n",
     "\n",
-    "last run successfully: April 26, 2023"
+    "last run successfully: August 2, 2023"
    ]
   },
   {
@@ -47,7 +47,7 @@
     ")\n",
     "from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.core.utilStages import ColumnMapper"
+    "from rail.core.utilStages import ColumnMapper\n"
    ]
   },
   {
@@ -58,7 +58,10 @@
    "source": [
     "import pzflow\n",
     "import os\n",
-    "flow_file = os.path.join(os.path.dirname(pzflow.__file__), 'example_files', 'example-flow.pzflow.pkl')"
+    "\n",
+    "flow_file = os.path.join(\n",
+    "    os.path.dirname(pzflow.__file__), \"example_files\", \"example-flow.pzflow.pkl\"\n",
+    ")\n"
    ]
   },
   {
@@ -75,7 +78,7 @@
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
-    "DS.__class__.allow_overwrite = True"
+    "DS.__class__.allow_overwrite = True\n"
    ]
   },
   {
@@ -95,11 +98,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n_samples=6\n",
+    "n_samples = 6\n",
     "# create the FlowCreator\n",
-    "flowCreator = FlowCreator.make_stage(name='truth', model=flow_file, n_samples=n_samples)\n",
+    "flowCreator = FlowCreator.make_stage(name=\"truth\", model=flow_file, n_samples=n_samples)\n",
     "# draw a few samples\n",
-    "samples_truth = flowCreator.sample(6, seed=0)"
+    "samples_truth = flowCreator.sample(6, seed=0)\n"
    ]
   },
   {
@@ -119,12 +122,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow_post = FlowPosterior.make_stage(name='truth_post', \n",
-    "                                             column='redshift',\n",
-    "                                             grid = np.linspace(0, 2.5, 100),\n",
-    "                                             marg_rules=dict(flag=np.nan, \n",
-    "                                                             u=lambda row: np.linspace(25, 31, 10)),\n",
-    "                                             flow=flow_file)"
+    "flow_post = FlowPosterior.make_stage(\n",
+    "    name=\"truth_post\",\n",
+    "    column=\"redshift\",\n",
+    "    grid=np.linspace(0, 2.5, 100),\n",
+    "    marg_rules=dict(flag=np.nan, u=lambda row: np.linspace(25, 31, 10)),\n",
+    "    flow=flow_file,\n",
+    ")\n"
    ]
   },
   {
@@ -133,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pdfs = flow_post.get_posterior(samples_truth, column='redshift')"
+    "pdfs = flow_post.get_posterior(samples_truth, column=\"redshift\")\n"
    ]
   },
   {
@@ -149,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pdfs.data"
+    "pdfs.data\n"
    ]
   },
   {
@@ -168,7 +172,6 @@
     "fig, axes = plt.subplots(2, 3, constrained_layout=True, dpi=120)\n",
     "\n",
     "for i, ax in enumerate(axes.flatten()):\n",
-    "\n",
     "    # plot the pdf\n",
     "    pdfs.data[i].plot_native(axes=ax)\n",
     "\n",
@@ -183,7 +186,7 @@
     "        ax.set(xlabel=\"redshift\")\n",
     "    # set y-label on far left column\n",
     "    if i % 3 == 0:\n",
-    "        ax.set(ylabel=\"p(z)\")"
+    "        ax.set(ylabel=\"p(z)\")\n"
    ]
   },
   {
@@ -205,8 +208,8 @@
     "\n",
     "I will make one change however:\n",
     "the LSST Error Model sometimes results in non-detections for faint galaxies.\n",
-    "These non-detections are flagged with NaN.\n",
-    "Calculating posteriors for galaxies with missing magnitudes is more complicated, so for now, I will add one additional QuantityCut to remove any galaxies with missing magnitudes.\n",
+    "These non-detections are flagged with inf.\n",
+    "Calculating posteriors for galaxies with non-detections is more complicated, so for now, I will add one additional QuantityCut to remove any galaxies with missing magnitudes.\n",
     "To see how to calculate posteriors for galaxies with missing magnitudes, see [Section 3](#MissingBands)."
    ]
   },
@@ -225,27 +228,42 @@
    "source": [
     "# set up the error model\n",
     "\n",
-    "n_samples=20\n",
+    "n_samples = 30\n",
     "# create the FlowEngine\n",
-    "flowEngine_degr = FlowCreator.make_stage(name='degraded', flow_file=flow_file, n_samples=n_samples)\n",
+    "flowEngine_degr = FlowCreator.make_stage(\n",
+    "    name=\"degraded\", flow_file=flow_file, n_samples=n_samples\n",
+    ")\n",
     "# draw a few samples\n",
-    "samples_degr = flowEngine_degr.sample(20, seed=0)\n",
-    "errorModel = LSSTErrorModel.make_stage(name='lsst_errors', input='xx')\n",
-    "quantityCut = QuantityCut.make_stage(name='gold_cut',  input='xx', cuts={band: np.inf for band in \"ugrizy\"})\n",
-    "inv_incomplete = InvRedshiftIncompleteness.make_stage(name='incompleteness', pivot_redshift=0.8)\n",
+    "samples_degr = flowEngine_degr.sample(n_samples, seed=0)\n",
+    "errorModel = LSSTErrorModel.make_stage(name=\"lsst_errors\", input=\"xx\", sigLim=5)\n",
+    "quantityCut = QuantityCut.make_stage(\n",
+    "    name=\"gold_cut\", input=\"xx\", cuts={band: np.inf for band in \"ugrizy\"}\n",
+    ")\n",
+    "inv_incomplete = InvRedshiftIncompleteness.make_stage(\n",
+    "    name=\"incompleteness\", pivot_redshift=0.8\n",
+    ")\n",
     "\n",
     "OII = 3727\n",
     "OIII = 5007\n",
     "\n",
-    "lc_2p_0II_0III = LineConfusion.make_stage(name='lc_2p_0II_0III', \n",
-    "                                          true_wavelen=OII, wrong_wavelen=OIII, frac_wrong=0.02)\n",
-    "lc_1p_0III_0II = LineConfusion.make_stage(name='lc_1p_0III_0II',\n",
-    "                                          true_wavelen=OIII, wrong_wavelen=OII, frac_wrong=0.01)\n",
-    "detection = QuantityCut.make_stage(name='detection', cuts={\"i\": 25.3})\n",
+    "lc_2p_0II_0III = LineConfusion.make_stage(\n",
+    "    name=\"lc_2p_0II_0III\", true_wavelen=OII, wrong_wavelen=OIII, frac_wrong=0.02\n",
+    ")\n",
+    "lc_1p_0III_0II = LineConfusion.make_stage(\n",
+    "    name=\"lc_1p_0III_0II\", true_wavelen=OIII, wrong_wavelen=OII, frac_wrong=0.01\n",
+    ")\n",
+    "detection = QuantityCut.make_stage(name=\"detection\", cuts={\"i\": 25.3})\n",
     "\n",
     "data = samples_degr\n",
-    "for degr in [errorModel, quantityCut, inv_incomplete, lc_2p_0II_0III, lc_1p_0III_0II, detection]:\n",
-    "    data = degr(data)"
+    "for degr in [\n",
+    "    errorModel,\n",
+    "    quantityCut,\n",
+    "    inv_incomplete,\n",
+    "    lc_2p_0II_0III,\n",
+    "    lc_1p_0III_0II,\n",
+    "    detection,\n",
+    "]:\n",
+    "    data = degr(data)\n"
    ]
   },
   {
@@ -255,7 +273,7 @@
    "outputs": [],
    "source": [
     "samples_degraded_wo_nondetects = data.data\n",
-    "samples_degraded_wo_nondetects"
+    "samples_degraded_wo_nondetects\n"
    ]
   },
   {
@@ -276,9 +294,11 @@
    "outputs": [],
    "source": [
     "grid = np.linspace(0, 2.5, 100)\n",
+    "\n",
+    "\n",
     "def get_degr_post(key, data, **kwargs):\n",
-    "    flow_degr_post = FlowPosterior.make_stage(name=f'degr_post_{key}', **kwargs) \n",
-    "    return flow_degr_post.get_posterior(data, column='redshift')"
+    "    flow_degr_post = FlowPosterior.make_stage(name=f\"degr_post_{key}\", **kwargs)\n",
+    "    return flow_degr_post.get_posterior(data, column=\"redshift\")\n"
    ]
   },
   {
@@ -287,14 +307,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "degr_kwargs = dict(column='redshift', flow_file=flow_file, \n",
-    "                   marg_rules=dict(flag=np.nan, u=lambda row: np.linspace(25, 31, 10)),\n",
-    "                   grid=grid, seed=0, batch_size=2)\n",
+    "degr_kwargs = dict(\n",
+    "    column=\"redshift\",\n",
+    "    flow_file=flow_file,\n",
+    "    marg_rules=dict(flag=np.nan, u=lambda row: np.linspace(25, 31, 10)),\n",
+    "    grid=grid,\n",
+    "    seed=0,\n",
+    "    batch_size=2,\n",
+    ")\n",
     "pdfs_errs_convolved = {\n",
-    "    err_samples: get_degr_post(f'{str(err_samples)}', data,\n",
-    "                               err_samples=err_samples, **degr_kwargs)\n",
+    "    err_samples: get_degr_post(\n",
+    "        f\"{str(err_samples)}\", data, err_samples=err_samples, **degr_kwargs\n",
+    "    )\n",
     "    for err_samples in [1, 10, 100, 1000]\n",
-    "}"
+    "}\n"
    ]
   },
   {
@@ -306,12 +332,10 @@
     "fig, axes = plt.subplots(2, 3, dpi=120)\n",
     "\n",
     "for i, ax in enumerate(axes.flatten()):\n",
-    "\n",
     "    # set dummy values for xlim\n",
     "    xlim = [np.inf, -np.inf]\n",
     "\n",
     "    for pdfs_ in pdfs_errs_convolved.values():\n",
-    "\n",
     "        # plot the pdf\n",
     "        pdfs_.data[i].plot_native(axes=ax)\n",
     "\n",
@@ -319,15 +343,15 @@
     "        xmin = grid[np.argmax(pdfs_.data[i].pdf(grid)[0] > 2)]\n",
     "        if xmin < xlim[0]:\n",
     "            xlim[0] = xmin\n",
-    "            \n",
-    "        # get the x value where the pdf finally falls below 2   \n",
+    "\n",
+    "        # get the x value where the pdf finally falls below 2\n",
     "        xmax = grid[-np.argmax(pdfs_.data[i].pdf(grid)[0, ::-1] > 2)]\n",
     "        if xmax > xlim[1]:\n",
     "            xlim[1] = xmax\n",
     "\n",
     "    # plot the true redshift\n",
-    "    #z_true = samples_degraded_wo_nondetects[\"redshift\"][i]\n",
-    "    #ax.axvline(z_true, c=\"k\", ls=\"--\")\n",
+    "    z_true = samples_degraded_wo_nondetects[\"redshift\"].iloc[i]\n",
+    "    ax.axvline(z_true, c=\"k\", ls=\"--\")\n",
     "\n",
     "    # set x-label on bottom row\n",
     "    if i >= 3:\n",
@@ -346,12 +370,12 @@
     "for i, n in enumerate([10, 100, 1000]):\n",
     "    axes[0, 1].plot([], [], c=f\"C{i+1}\", label=f\"{n} samples\")\n",
     "axes[0, 1].legend(\n",
-    "    bbox_to_anchor=(0.5, 1.3), \n",
+    "    bbox_to_anchor=(0.5, 1.3),\n",
     "    loc=\"upper center\",\n",
     "    ncol=4,\n",
     ")\n",
     "\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -360,88 +384,7 @@
    "source": [
     "You can see the effect of convolving the errors. In particular, notice that without error convolution (1 sample), the redshift posterior is often totally inconsistent with the true redshift (marked by the vertical black line). As you convolve more samples, the posterior generally broadens and becomes consistent with the true redshift.\n",
     "\n",
-    "Also notice how the posterior continues to change as you convolve more and more samples. This suggests that you need to do a little testing to ensure that you have convolved enough samples.\n",
-    "\n",
-    "Let's plot these same posteriors with even more samples to make sure they have converged:\n",
-    "\n",
-    "**WARNING**: Running the next cell on your computer may exhaust your memory"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pdfs_errs_convolved_more_samples = {\n",
-    "    err_samples: get_degr_post(f'{str(err_samples)}', data,\n",
-    "                               err_samples=err_samples, **degr_kwargs)\n",
-    "#    for err_samples in [1000, 2000, 5000, 10000]\n",
-    "    for err_samples in [12]\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axes = plt.subplots(2, 3, dpi=120)\n",
-    "\n",
-    "for i, ax in enumerate(axes.flatten()):\n",
-    "\n",
-    "    # set dummy values for xlim\n",
-    "    xlim = [np.inf, -np.inf]\n",
-    "\n",
-    "    for pdfs_ in pdfs_errs_convolved_more_samples.values():\n",
-    "\n",
-    "        # plot the pdf\n",
-    "        pdfs_.data[i].plot_native(axes=ax)\n",
-    "\n",
-    "        # get the x value where the pdf first rises above 2\n",
-    "        xmin = grid[np.argmax(pdfs_.data[i].pdf(grid)[0] > 2)]\n",
-    "        if xmin < xlim[0]:\n",
-    "            xlim[0] = xmin\n",
-    "            \n",
-    "        # get the x value where the pdf finally falls below 2\n",
-    "        xmax = grid[-np.argmax(pdfs_.data[i].pdf(grid)[0, ::-1] > 2)]\n",
-    "        if xmax > xlim[1]:\n",
-    "            xlim[1] = xmax\n",
-    "\n",
-    "    # plot the true redshift\n",
-    "    #z_true = samples_degraded_wo_nondetects[\"redshift\"][i]\n",
-    "    #ax.axvline(z_true, c=\"k\", ls=\"--\")\n",
-    "\n",
-    "    # set x-label on bottom row\n",
-    "    if i >= 3:\n",
-    "        ax.set(xlabel=\"redshift\")\n",
-    "    # set y-label on far left column\n",
-    "    if i % 3 == 0:\n",
-    "        ax.set(ylabel=\"p(z)\")\n",
-    "\n",
-    "    # set the x-limits so we can see more detail\n",
-    "    xlim[0] -= 0.2\n",
-    "    xlim[1] += 0.2\n",
-    "    ax.set(xlim=xlim, yticks=[])\n",
-    "\n",
-    "# create the legend\n",
-    "for i, n in enumerate([1000, 2000, 5000, 10000]):\n",
-    "    axes[0, 1].plot([], [], c=f\"C{i}\", label=f\"{n} samples\")\n",
-    "axes[0, 1].legend(\n",
-    "    bbox_to_anchor=(0.5, 1.3), \n",
-    "    loc=\"upper center\",\n",
-    "    ncol=4,\n",
-    ")\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Notice that two of these galaxies may take upwards of 10,000 samples to converge (convolving over 10,000 samples takes 0.5 seconds / galaxy on my computer)"
+    "Also notice how the posterior continues to change as you convolve more and more samples. This suggests that you need to do a little testing to ensure that you have convolved enough samples."
    ]
   },
   {
@@ -461,7 +404,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples_degraded = DS['output_lc_1p_0III_0II']"
+    "samples_degraded = DS[\"output_lc_1p_0III_0II\"]\n"
    ]
   },
   {
@@ -480,21 +423,21 @@
    "outputs": [],
    "source": [
     "# get true u band magnitudes\n",
-    "true_u = DS['output_degraded'].data[\"u\"].to_numpy()\n",
+    "true_u = DS[\"output_degraded\"].data[\"u\"].to_numpy()\n",
     "# get the observed u band magnitudes\n",
-    "obs_u = DS['output_lsst_errors'].data[\"u\"].to_numpy()\n",
+    "obs_u = DS[\"output_lsst_errors\"].data[\"u\"].to_numpy()\n",
     "\n",
     "# create the figure\n",
     "fig, ax = plt.subplots(constrained_layout=True, dpi=100)\n",
     "# plot the u band detections\n",
-    "ax.hist(true_u[~np.isnan(obs_u)], bins=\"fd\", label=\"detected\")\n",
+    "ax.hist(true_u[np.isfinite(obs_u)], bins=10, range=(23, 31), label=\"detected\")\n",
     "# plot the u band non-detections\n",
-    "ax.hist(true_u[np.isnan(obs_u)], bins=\"fd\", label=\"non-detected\")\n",
+    "ax.hist(true_u[~np.isfinite(obs_u)], bins=10, range=(23, 31), label=\"non-detected\")\n",
     "\n",
     "ax.legend()\n",
     "ax.set(xlabel=\"true u magnitude\")\n",
     "\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -517,32 +460,33 @@
    "outputs": [],
    "source": [
     "from rail.core.utilStages import RowSelector\n",
+    "\n",
     "# dict to save the marginalized posteriors\n",
     "pdfs_u_marginalized = {}\n",
     "\n",
-    "row3_selector = RowSelector.make_stage(name='select_row3', start=3, stop=4)\n",
+    "row3_selector = RowSelector.make_stage(name=\"select_row3\", start=3, stop=4)\n",
     "row3_degraded = row3_selector(samples_degraded)\n",
     "\n",
-    "degr_post_kwargs = dict(grid=grid, err_samples=10000, seed=0, flow_file=flow_file, column='redshift')\n",
+    "degr_post_kwargs = dict(\n",
+    "    grid=grid, err_samples=10000, seed=0, flow_file=flow_file, column=\"redshift\"\n",
+    ")\n",
     "\n",
     "# iterate over variable grid resolution\n",
     "for nbins in [10, 20, 50, 100]:\n",
-    "\n",
     "    # set up the marginalization rules for this grid resolution\n",
     "    marg_rules = {\n",
     "        \"flag\": errorModel.config[\"ndFlag\"],\n",
-    "        \"u\": lambda row: np.linspace(27, 31, nbins)\n",
+    "        \"u\": lambda row: np.linspace(27, 31, nbins),\n",
     "    }\n",
     "\n",
-    "    \n",
     "    # calculate the posterior by marginalizing over u and sampling\n",
     "    # from the error distributions of the other galaxies\n",
-    "    pdfs_u_marginalized[nbins] = get_degr_post(f'degr_post_nbins_{nbins}',\n",
-    "                                               row3_degraded,\n",
-    "                                               marg_rules=marg_rules,\n",
-    "                                               **degr_post_kwargs)\n",
-    "\n",
-    "    "
+    "    pdfs_u_marginalized[nbins] = get_degr_post(\n",
+    "        f\"degr_post_nbins_{nbins}\",\n",
+    "        row3_degraded,\n",
+    "        marg_rules=marg_rules,\n",
+    "        **degr_post_kwargs,\n",
+    "    )\n"
    ]
   },
   {
@@ -557,7 +501,7 @@
     "ax.axvline(samples_degraded().iloc[3][\"redshift\"], label=\"True redshift\", c=\"k\")\n",
     "ax.legend()\n",
     "ax.set(xlabel=\"Redshift\")\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -566,75 +510,7 @@
    "source": [
     "Notice that the resolution with only 10 bins is sufficient for this marginalization.\n",
     "\n",
-    "In this example, only one of the bands featured a non-detection, but you can easily marginalize over more bands by including corresponding rules in the `marg_rules` dict. For example, let's artificially force a non-detection in the y band as well:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "row3_degraded()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sample_double_degraded = row3_degraded().copy()\n",
-    "sample_double_degraded.iloc[0, 11:] *= np.nan\n",
-    "DS.add_data('double_degr', sample_double_degraded, TableHandle)\n",
-    "sample_double_degraded"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set up the marginalization rules for u and y marginalization\n",
-    "marg_rules = {\n",
-    "    \"flag\": errorModel.config.ndFlag,\n",
-    "    \"u\": lambda row: np.linspace(27, 31, 10),\n",
-    "    \"y\": lambda row: np.linspace(21, 25, 10),\n",
-    "}\n",
-    "\n",
-    "# calculate the posterior by marginalizing over u and y, and sampling\n",
-    "# from the error distributions of the other galaxies\n",
-    "#pdf_double_marginalized = get_degr_post('double_degr', \n",
-    "#                                        DS['double_degr'],\n",
-    "#                                        flow_file=flow_file,\n",
-    "#                                        input='xx',\n",
-    "#                                        column='redshift',\n",
-    "#                                        grid=grid, \n",
-    "#                                        err_samples=10000, \n",
-    "#                                        seed=0, \n",
-    "#                                        marg_rules=marg_rules)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#fig, ax = plt.subplots(dpi=100)\n",
-    "#pdf_double_marginalized.data[0].plot_native(axes=ax)\n",
-    "#ax.axvline(sample_double_degraded.iloc[0][\"redshift\"], label=\"True redshift\", c=\"k\")\n",
-    "#ax.legend()\n",
-    "#ax.set(xlabel=\"Redshift\")\n",
-    "#plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that marginalizing over multiple bands quickly gets expensive."
+    "In this example, only one of the bands featured a non-detection, but you can easily marginalize over more bands by including corresponding rules in the `marg_rules` dict.  Note that marginalizing over multiple bands quickly gets expensive."
    ]
   }
  ],
@@ -654,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -61,7 +61,7 @@
     "import numpy as np\n",
     "from pathlib import Path\n",
     "from pzflow.examples import get_galaxy_data\n",
-    "import tables_io"
+    "import tables_io\n"
    ]
   },
   {
@@ -74,7 +74,10 @@
     "# Various rail modules\n",
     "import rail\n",
     "from rail.creation.degradation.lsst_error_model import LSSTErrorModel\n",
-    "from rail.creation.degradation.spectroscopic_degraders import InvRedshiftIncompleteness, LineConfusion\n",
+    "from rail.creation.degradation.spectroscopic_degraders import (\n",
+    "    InvRedshiftIncompleteness,\n",
+    "    LineConfusion,\n",
+    ")\n",
     "from rail.creation.degradation.quantityCut import QuantityCut\n",
     "from rail.creation.engines.flowEngine import FlowModeler, FlowCreator, FlowPosterior\n",
     "from rail.core.data import TableHandle\n",
@@ -88,8 +91,7 @@
     "from rail.estimation.algos.naive_stack import NaiveStackSummarizer\n",
     "from rail.estimation.algos.point_est_hist import PointEstHistSummarizer\n",
     "\n",
-    "from rail.evaluation.evaluator import Evaluator\n",
-    "\n"
+    "from rail.evaluation.evaluator import Evaluator\n"
    ]
   },
   {
@@ -112,7 +114,7 @@
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
-    "DS.__class__.allow_overwrite = True"
+    "DS.__class__.allow_overwrite = True\n"
    ]
   },
   {
@@ -131,10 +133,11 @@
    "outputs": [],
    "source": [
     "from rail.core.utils import RAILDIR\n",
-    "flow_file = os.path.join(RAILDIR, 'examples/goldenspike/data/pretrained_flow.pkl')\n",
-    "bands = ['u','g','r','i','z','y']\n",
-    "band_dict = {band:f'mag_{band}_lsst' for band in bands}\n",
-    "rename_dict = {f'mag_{band}_lsst_err':f'mag_err_{band}_lsst' for band in bands}"
+    "\n",
+    "flow_file = os.path.join(RAILDIR, \"examples/goldenspike/data/pretrained_flow.pkl\")\n",
+    "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
+    "band_dict = {band: f\"mag_{band}_lsst\" for band in bands}\n",
+    "rename_dict = {f\"mag_{band}_lsst_err\": f\"mag_err_{band}_lsst\" for band in bands}\n"
    ]
   },
   {
@@ -164,7 +167,7 @@
     "tables_io.write(catalog, str(catalog_file.with_suffix(\"\")), catalog_file.suffix[1:])\n",
     "\n",
     "catalog_file = str(catalog_file)\n",
-    "flow_file = str(DATA_DIR / \"trained_flow.pkl\")"
+    "flow_file = str(DATA_DIR / \"trained_flow.pkl\")\n"
    ]
   },
   {
@@ -197,7 +200,7 @@
     "        \"mag_y_lsst\": [14, 28],\n",
     "    },\n",
     "    \"calc_colors\": {\"ref_column_name\": \"mag_i_lsst\"},\n",
-    "}"
+    "}\n"
    ]
   },
   {
@@ -215,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow_modeler = FlowModeler.make_stage(**flow_modeler_params)"
+    "flow_modeler = FlowModeler.make_stage(**flow_modeler_params)\n"
    ]
   },
   {
@@ -225,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow_modeler.fit_model()"
+    "flow_modeler.fit_model()\n"
    ]
   },
   {
@@ -260,44 +263,44 @@
    "outputs": [],
    "source": [
     "flow_creator_train = FlowCreator.make_stage(\n",
-    "    name='flow_creator_train', \n",
-    "    model=flow_modeler.get_handle(\"model\"), \n",
+    "    name=\"flow_creator_train\",\n",
+    "    model=flow_modeler.get_handle(\"model\"),\n",
     "    n_samples=50,\n",
     "    seed=1235,\n",
     ")\n",
     "\n",
     "lsst_error_model_train = LSSTErrorModel.make_stage(\n",
-    "    name='lsst_error_model_train',\n",
-    "    bandNames=band_dict, \n",
+    "    name=\"lsst_error_model_train\",\n",
+    "    renameDict=band_dict,\n",
     "    seed=29,\n",
     ")\n",
     "\n",
     "inv_redshift = InvRedshiftIncompleteness.make_stage(\n",
-    "    name='inv_redshift',\n",
+    "    name=\"inv_redshift\",\n",
     "    pivot_redshift=1.0,\n",
     ")\n",
     "\n",
     "line_confusion = LineConfusion.make_stage(\n",
-    "    name='line_confusion', \n",
-    "    true_wavelen=5007., \n",
-    "    wrong_wavelen=3727.,\n",
+    "    name=\"line_confusion\",\n",
+    "    true_wavelen=5007.0,\n",
+    "    wrong_wavelen=3727.0,\n",
     "    frac_wrong=0.05,\n",
     ")\n",
     "\n",
     "quantity_cut = QuantityCut.make_stage(\n",
-    "    name='quantity_cut',    \n",
-    "    cuts={'mag_i_lsst': 25.0},\n",
+    "    name=\"quantity_cut\",\n",
+    "    cuts={\"mag_i_lsst\": 25.0},\n",
     ")\n",
     "\n",
     "col_remapper_train = ColumnMapper.make_stage(\n",
-    "    name='col_remapper_train', \n",
+    "    name=\"col_remapper_train\",\n",
     "    columns=rename_dict,\n",
     ")\n",
-    "   \n",
+    "\n",
     "table_conv_train = TableConverter.make_stage(\n",
-    "    name='table_conv_train', \n",
-    "    output_format='numpyDict',\n",
-    ")"
+    "    name=\"table_conv_train\",\n",
+    "    output_format=\"numpyDict\",\n",
+    ")\n"
    ]
   },
   {
@@ -308,12 +311,12 @@
    "outputs": [],
    "source": [
     "train_data_orig = flow_creator_train.sample(150, 1235)\n",
-    "train_data_errs = lsst_error_model_train(train_data_orig,seed=66)\n",
+    "train_data_errs = lsst_error_model_train(train_data_orig, seed=66)\n",
     "train_data_inc = inv_redshift(train_data_errs)\n",
     "train_data_conf = line_confusion(train_data_inc)\n",
     "train_data_cut = quantity_cut(train_data_conf)\n",
     "train_data_pq = col_remapper_train(train_data_cut)\n",
-    "train_data = table_conv_train(train_data_pq)"
+    "train_data = table_conv_train(train_data_pq)\n"
    ]
   },
   {
@@ -332,7 +335,7 @@
    "outputs": [],
    "source": [
     "train_table = tables_io.convertObj(train_data.data, tables_io.types.PD_DATAFRAME)\n",
-    "train_table.head()"
+    "train_table.head()\n"
    ]
   },
   {
@@ -367,32 +370,32 @@
    "outputs": [],
    "source": [
     "flow_creator_test = FlowCreator.make_stage(\n",
-    "    name='flow_creator_test',\n",
+    "    name=\"flow_creator_test\",\n",
     "    model=flow_modeler.get_handle(\"model\"),\n",
     "    n_samples=50,\n",
     ")\n",
-    "      \n",
+    "\n",
     "lsst_error_model_test = LSSTErrorModel.make_stage(\n",
-    "    name='lsst_error_model_test',\n",
-    "    bandNames=band_dict,\n",
+    "    name=\"lsst_error_model_test\",\n",
+    "    renameDict=band_dict,\n",
     ")\n",
     "\n",
     "flow_post_test = FlowPosterior.make_stage(\n",
-    "    name='flow_post_test',\n",
+    "    name=\"flow_post_test\",\n",
     "    model=flow_modeler.get_handle(\"model\"),\n",
-    "    column='redshift',\n",
-    "    grid=np.linspace(0., 5., 21),\n",
+    "    column=\"redshift\",\n",
+    "    grid=np.linspace(0.0, 5.0, 21),\n",
     ")\n",
-    "                \n",
+    "\n",
     "col_remapper_test = ColumnMapper.make_stage(\n",
-    "    name='col_remapper_test',\n",
+    "    name=\"col_remapper_test\",\n",
     "    columns=rename_dict,\n",
-    "    hdf5_groupname='',\n",
+    "    hdf5_groupname=\"\",\n",
     ")\n",
     "\n",
     "table_conv_test = TableConverter.make_stage(\n",
-    "    name='table_conv_test', \n",
-    "    output_format='numpyDict',\n",
+    "    name=\"table_conv_test\",\n",
+    "    output_format=\"numpyDict\",\n",
     ")\n"
    ]
   },
@@ -404,10 +407,10 @@
    "outputs": [],
    "source": [
     "test_data_orig = flow_creator_test.sample(150, 1234)\n",
-    "test_data_errs = lsst_error_model_test(test_data_orig,seed=58)\n",
+    "test_data_errs = lsst_error_model_test(test_data_orig, seed=58)\n",
     "test_data_post = flow_post_test.get_posterior(test_data_errs, err_samples=None)\n",
     "test_data_pq = col_remapper_test(test_data_errs)\n",
-    "test_data = table_conv_test(test_data_pq)"
+    "test_data = table_conv_test(test_data_pq)\n"
    ]
   },
   {
@@ -418,7 +421,7 @@
    "outputs": [],
    "source": [
     "test_table = tables_io.convertObj(test_data.data, tables_io.types.PD_DATAFRAME)\n",
-    "test_table.head()"
+    "test_table.head()\n"
    ]
   },
   {
@@ -448,17 +451,17 @@
     ")\n",
     "\n",
     "inform_knn = KNearNeighInformer.make_stage(\n",
-    "    name='inform_knn', \n",
+    "    name=\"inform_knn\",\n",
     "    nondetect_val=np.nan,\n",
-    "    model='knnpz.pkl', \n",
-    "    hdf5_groupname='',\n",
+    "    model=\"knnpz.pkl\",\n",
+    "    hdf5_groupname=\"\",\n",
     ")\n",
     "\n",
     "inform_fzboost = FlexZBoostInformer.make_stage(\n",
-    "    name='inform_FZBoost', \n",
-    "    model='fzboost.pkl', \n",
-    "    hdf5_groupname='',\n",
-    ")"
+    "    name=\"inform_FZBoost\",\n",
+    "    model=\"fzboost.pkl\",\n",
+    "    hdf5_groupname=\"\",\n",
+    ")\n"
    ]
   },
   {
@@ -470,7 +473,7 @@
    "source": [
     "inform_bpz.inform(train_data)\n",
     "inform_knn.inform(train_data)\n",
-    "inform_fzboost.inform(train_data)"
+    "inform_fzboost.inform(train_data)\n"
    ]
   },
   {
@@ -495,25 +498,25 @@
    "outputs": [],
    "source": [
     "estimate_bpz = BPZliteEstimator.make_stage(\n",
-    "    name='estimate_bpz', \n",
-    "    hdf5_groupname='', \n",
-    "    model=inform_bpz.get_handle('model'),\n",
+    "    name=\"estimate_bpz\",\n",
+    "    hdf5_groupname=\"\",\n",
+    "    model=inform_bpz.get_handle(\"model\"),\n",
     ")\n",
     "\n",
     "estimate_knn = KNearNeighEstimator.make_stage(\n",
-    "    name='estimate_knn', \n",
-    "    hdf5_groupname='', \n",
-    "    nondetect_val=np.nan, \n",
-    "    model=inform_knn.get_handle('model'),\n",
+    "    name=\"estimate_knn\",\n",
+    "    hdf5_groupname=\"\",\n",
+    "    nondetect_val=np.nan,\n",
+    "    model=inform_knn.get_handle(\"model\"),\n",
     ")\n",
     "\n",
     "estimate_fzboost = FlexZBoostEstimator.make_stage(\n",
-    "    name='test_FZBoost', \n",
+    "    name=\"test_FZBoost\",\n",
     "    nondetect_val=np.nan,\n",
-    "    model=inform_fzboost.get_handle('model'), \n",
-    "    hdf5_groupname='',\n",
-    "    aliases=dict(input='test_data', output='fzboost_estim'),\n",
-    ")"
+    "    model=inform_fzboost.get_handle(\"model\"),\n",
+    "    hdf5_groupname=\"\",\n",
+    "    aliases=dict(input=\"test_data\", output=\"fzboost_estim\"),\n",
+    ")\n"
    ]
   },
   {
@@ -525,7 +528,7 @@
    "source": [
     "knn_estimated = estimate_knn.estimate(test_data)\n",
     "fzboost_estimated = estimate_fzboost.estimate(test_data)\n",
-    "bpz_estimated = estimate_bpz.estimate(test_data)"
+    "bpz_estimated = estimate_bpz.estimate(test_data)\n"
    ]
   },
   {
@@ -553,8 +556,8 @@
     "\n",
     "result_dict = {}\n",
     "for key, val in eval_dict.items():\n",
-    "    the_eval = Evaluator.make_stage(name=f'{key}_eval', truth=truth)\n",
-    "    result_dict[key] = the_eval.evaluate(val, truth)"
+    "    the_eval = Evaluator.make_stage(name=f\"{key}_eval\", truth=truth)\n",
+    "    result_dict[key] = the_eval.evaluate(val, truth)\n"
    ]
   },
   {
@@ -573,7 +576,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_tables = {key:tables_io.convertObj(val.data, tables_io.types.PD_DATAFRAME) for key,val in result_dict.items()}"
+    "results_tables = {\n",
+    "    key: tables_io.convertObj(val.data, tables_io.types.PD_DATAFRAME)\n",
+    "    for key, val in result_dict.items()\n",
+    "}\n"
    ]
   },
   {
@@ -583,7 +589,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_tables['knn']"
+    "results_tables[\"knn\"]\n"
    ]
   },
   {
@@ -593,7 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_tables['fzboost']"
+    "results_tables[\"fzboost\"]\n"
    ]
   },
   {
@@ -603,7 +609,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_tables['bpz']"
+    "results_tables[\"bpz\"]\n"
    ]
   },
   {
@@ -625,8 +631,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "point_estimate_test = PointEstHistSummarizer.make_stage(name='point_estimate_test')\n",
-    "naive_stack_test = NaiveStackSummarizer.make_stage(name='naive_stack_test')"
+    "point_estimate_test = PointEstHistSummarizer.make_stage(name=\"point_estimate_test\")\n",
+    "naive_stack_test = NaiveStackSummarizer.make_stage(name=\"naive_stack_test\")\n"
    ]
   },
   {
@@ -636,8 +642,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "point_estimate_ens = point_estimate_test.summarize(eval_dict['bpz'])\n",
-    "naive_stack_ens = naive_stack_test.summarize(eval_dict['bpz'])"
+    "point_estimate_ens = point_estimate_test.summarize(eval_dict[\"bpz\"])\n",
+    "naive_stack_ens = naive_stack_test.summarize(eval_dict[\"bpz\"])\n"
    ]
   },
   {
@@ -647,7 +653,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = naive_stack_ens.data.plot_native(xlim=(0,3))"
+    "_ = naive_stack_ens.data.plot_native(xlim=(0, 3))\n"
    ]
   },
   {
@@ -657,7 +663,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = point_estimate_ens.data.plot_native(xlim=(0,3))"
+    "_ = point_estimate_ens.data.plot_native(xlim=(0, 3))\n"
    ]
   },
   {
@@ -678,24 +684,38 @@
    "outputs": [],
    "source": [
     "import ceci\n",
+    "\n",
     "pipe = ceci.Pipeline.interactive()\n",
     "stages = [\n",
     "    # train the flow\n",
     "    flow_modeler,\n",
     "    # create the training catalog\n",
-    "    flow_creator_train, lsst_error_model_train, inv_redshift,\n",
-    "    line_confusion, quantity_cut, col_remapper_train, table_conv_train,\n",
+    "    flow_creator_train,\n",
+    "    lsst_error_model_train,\n",
+    "    inv_redshift,\n",
+    "    line_confusion,\n",
+    "    quantity_cut,\n",
+    "    col_remapper_train,\n",
+    "    table_conv_train,\n",
     "    # create the test catalog\n",
-    "    flow_creator_test, lsst_error_model_test, col_remapper_test, table_conv_test,\n",
+    "    flow_creator_test,\n",
+    "    lsst_error_model_test,\n",
+    "    col_remapper_test,\n",
+    "    table_conv_test,\n",
     "    # inform the estimators\n",
-    "    inform_bpz, inform_knn, inform_fzboost,\n",
+    "    inform_bpz,\n",
+    "    inform_knn,\n",
+    "    inform_fzboost,\n",
     "    # estimate posteriors\n",
-    "    estimate_bpz, estimate_knn, estimate_fzboost,\n",
+    "    estimate_bpz,\n",
+    "    estimate_knn,\n",
+    "    estimate_fzboost,\n",
     "    # estimate n(z), aka \"summarize\"\n",
-    "    point_estimate_test, naive_stack_test,\n",
+    "    point_estimate_test,\n",
+    "    naive_stack_test,\n",
     "]\n",
     "for stage in stages:\n",
-    "    pipe.add_stage(stage)"
+    "    pipe.add_stage(stage)\n"
    ]
   },
   {
@@ -705,7 +725,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe.initialize(dict(input=catalog_file), dict(output_dir='.', log_dir='.', resume=False), None)"
+    "pipe.initialize(\n",
+    "    dict(input=catalog_file), dict(output_dir=\".\", log_dir=\".\", resume=False), None\n",
+    ")\n"
    ]
   },
   {
@@ -715,7 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe.save('tmp_goldenspike.yml')"
+    "pipe.save(\"tmp_goldenspike.yml\")\n"
    ]
   },
   {
@@ -733,7 +755,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr = ceci.Pipeline.read('tmp_goldenspike.yml')"
+    "pr = ceci.Pipeline.read(\"tmp_goldenspike.yml\")\n"
    ]
   },
   {
@@ -743,7 +765,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr.run()"
+    "pr.run()\n"
    ]
   },
   {
@@ -763,7 +785,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO fix and add clean up scripts"
+    "# TODO fix and add clean up scripts\n"
    ]
   }
  ],
@@ -783,7 +805,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the following tutorial notebooks to be consistent with the [PR](https://github.com/LSSTDESC/rail_astro_tools/pull/10) that adds the new `rail.creation.degradation.lsst_error_model` in `rail_astro_tools`:

- degradation demo
- photometric realization demo
- posterior demo
- pipe example
- golden spike