### PR TITLE
update very outdated markdown in notebook

### DIFF
--- a/examples/estimation_examples/RAIL_estimation_demo.ipynb
+++ b/examples/estimation_examples/RAIL_estimation_demo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# RAIL/Estimation Tutorial Notebook\n",
     "\n",
-    "author: Sam Schmidt, Eric Charles, others...\n",
+    "author: Sam Schmidt, Eric Charles, Alex Malz, others...\n",
     "\n",
     "last run successfully: August 4, 2023"
    ]
@@ -15,13 +15,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a notebook demonstrating some of the features of the LSSTDESC `RAIL` package, namely the features of `estimation`.  \n",
+    "This is a notebook demonstrating some of the `estimation` features of the LSST-DESC `RAIL`-iverse packages.  \n",
     "\n",
-    "`RAIL/estimation` is the interface for running production level photo-z codes within DESC.  There is a minimimal superclass that sets up some file paths and variable names, each specific photo-z code resides in a subclass with code-specific setup variables.  More extensive documentation is available on Read the Docs here:\n",
+    "The `rail.estimation` subpackage contains infrastructure to run multiple production-level photo-z codes.  There is a minimimal superclass that sets up some file paths and variable names. Each specific photo-z code resides in a subclass in `rail.estimation.algos` with algorithm-specific setup variables.  More extensive documentation is available on Read the Docs here:\n",
     "https://rail-hub.readthedocs.io/en/latest/\n",
     "\n",
-    "The source code for RAIL is available on GitHub at:\n",
-    "https://github.com/LSSTDESC/RAIL"
+    ""
    ]
   },
   {
@@ -52,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll start by setting up the Rail data store.  RAIL uses [ceci](https://github.com/LSSTDESC/ceci), which is designed for pipelines rather than interactive notebooks, the data store will work around that and enable us to use data interactively.   Some files will appear in the data store with the prefix \"inprogress_\" as they are stored in memory for use in the notebook, but the data will also be written out to file.  See the `RAIL/examples/goldenspike_examples/goldenspike.ipynb` example notebook for more details on the Data Store."
+    "We'll start by setting up the `DataStore`.  RAIL uses [`ceci`](https://github.com/LSSTDESC/ceci) as a back-end for pipelines of RAIL stages run at the command line. The `DataStore` is a workaround to enable `ceci` to interact with data files in an interactive notebook environment.   Some files will appear in the `DataStore` with the prefix \"inprogress_\" as they are stored in memory for use in the notebook, but the data will also be written out to file with the prefix \"output_\".  See the Golden Spike end-to-end demo notebook for more details on the `DataStore`."
    ]
   },
   {
@@ -71,7 +70,7 @@
    "source": [
     "### Importing all available estimators\n",
     "\n",
-    "There is some handy functionality in `rail.stages` to import all available stages that are installed in your environment.  RailStage knows about all of the sub-types of stages.  The are stored in the `RailStage.pipeline_stages` dict.  By looping through the values in that dict we can and asking if each one is a sub-class of `rail.estimation.estimator.CatEstimator` we can identify the available estimators that operator on catalog-like inputs.  Let's run this `import_and_attach_all()` command, and then print out the subclasses that are now available for use (though in this demo we only take advantage of two specific estimators):"
+    "There is some handy functionality in `rail.stages` to import all available stages that are installed in your environment.  `RailStage` knows about all of the sub-types of stages.  By looping through the values in  the `RailStage.pipeline_stages` dictionary, we can isolate those that are sub-classes of `rail.estimation.estimator.CatEstimator`, which operate on catalog-like inputs.  Let's run this `import_and_attach_all()` command, and then print out the subclasses that are now available for use (though in this demo we only take advantage of two specific estimators):"
    ]
   },
   {
@@ -92,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You should see a list of the available photo-z algorithms, as printed out above.  These are the names of the specific subclasses that invoke a particular method, and currently include:\n",
+    "You should see a list of the available subclasses corresponding to specific photo-z algorithms, as printed out above.  These currently include:\n",
     "\n",
     "- `BPZliteEstimator` is a template-based code that outputs the posterior estimated given a specific template set and Bayesian prior. See Benitez (2000) for more details.\n",
     "- `CMNNEstimator` is an implementation of the \"colour-matched nearest neighbour` estimator described in [Graham et al 2018](https://ui.adsabs.harvard.edu/abs/2018AJ....155....1G/abstract).  It returns a single Gaussian for each galaxy.\n",

--- a/examples/estimation_examples/RAIL_estimation_demo.ipynb
+++ b/examples/estimation_examples/RAIL_estimation_demo.ipynb
@@ -290,7 +290,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that KNearNeigh PDFs do consist of a number of discrete Gaussians, and many have quite a bit of substructure.  This is a naive estimator, and some of these feature are likely spurious."
+    "We see that KNearNeigh PDFs do consist of a number of discrete Gaussians, and many have quite a bit of substructure.  This is a naive estimator, and some of these features are likely spurious."
    ]
   },
   {
@@ -304,19 +304,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That illustrates the basics, now let's try the `FlexZBoostEstimator` estimator.  FlexZBoost has been moved out of the \"base\" RAIL repo, and is available in the [rail_flexzboost](https://github.com/LSSTDESC/rail_flexzboost/) repo.  You can install by cloning that repo and installing directly, or you can install it via PyPI by simply running the command\n",
+    "That illustrates the basics. Now let's try the `FlexZBoostEstimator` estimator.  FlexZBoost is available in the [rail_flexzboost](https://github.com/LSSTDESC/rail_flexzboost/) repo and can be installed with\n",
     "\n",
     "`pip install pz-rail-flexzboost`\n",
     "\n",
-    "on the command line.  Once installed, it will function the same as any of the other estimators included in the main RAIL repo.\n",
+    "on the command line or from source.  Once installed, it will function the same as any of the other estimators included in the primary `rail` repo.\n",
     "\n",
-    "`FlexZBoostEstimator` finds a conditional density estimate for each PDF via a set of weights for basis functions.  This can save space relative to a gridded parameterization, but it also sometimes leads to residual \"bumps\" in the PDF from the underlying parameterization.  For this reason, `FlexZBoostEstimator` has a post-processing stage where it \"trims\" (i.e. sets to zero) any \"bumps\" below a certain threshold.\n",
+    "`FlexZBoostEstimator` approximates the conditional density estimate for each PDF with a set of weights on a set of basis functions.  This can save space relative to a gridded parameterization, but it also sometimes leads to residual \"bumps\" in the PDF from the underlying parameterization.  For this reason, `FlexZBoostEstimator` has a post-processing stage where it \"trims\" (i.e. sets to zero) any small peaks, or \"bumps\", below a certain `bump_thresh` threshold.\n",
     "\n",
-    "One of the dominant features seen in our PhotoZDC1 analysis of multiple photo-z codes (Schmidt, Malz et al. 2020) was that photo-z estimates were often, in general, overconfident or underconfident in their overall uncertainty in PDFs.  To remedy this, `FlexZBoostEstimator` has an additional post-processing step where it estimates a \"sharpening\" parameter that modulates the width of the PDFs.\n",
+    "One of the dominant features seen in our PhotoZDC1 analysis of multiple photo-z codes (Schmidt, Malz et al. 2020) was that photo-z estimates were often, in general, overconfident or underconfident in their overall uncertainty in PDFs.  To remedy this, `FlexZBoostEstimator` has an additional post-processing step where it applies a \"sharpening\" parameter `sharpen` that modulates the width of the PDFs according to a power law.\n",
     "\n",
-    "A portion of the training data is held in reserve to find best-fit values for both `bump_thresh` and `sharpening`, which we find by simply calculating the CDE loss for a grid of `bump_thresh` and `sharpening` values, though once those values are set FlexZBoost will re-train its density estimate model with the full dataset.\n",
+    "A portion of the training data is held in reserve to determine best-fit values for both `bump_thresh` and `sharpening`, which we currently find by simply calculating the CDE loss for a grid of `bump_thresh` and `sharpening` values; once those values are set FlexZBoost will re-train its density estimate model with the full dataset. A more sophisticated hyperparameter fitting procedure may be implemented in the future.\n",
     "\n",
-    "We'll start with a dictionary of setup parameters for FlexZBoostEstimator, just as we had for the k-nearest neighbor estimator.  Some of the parameters are the same as in k-nearest neighbor above, `zmin`, `zmax`, `nzbins`.  However, FlexZBoostEstimator performs a more in depth training than simpleNN, and as such has more input parameters to control behavior.  These parameters are:\n",
+    "We'll start with a dictionary of setup parameters for FlexZBoostEstimator, just as we had for the k-nearest neighbor estimator.  Some of the parameters are the same as in k-nearest neighbor above, `zmin`, `zmax`, `nzbins`.  However, FlexZBoostEstimator performs a more in depth training and as such has more input parameters to control its behavior.  These parameters are:\n",
     "\n",
     "- `basis_system`: which basis system to use in the density estimate. The default is `cosine` but `fourier` is also an option\n",
     "- `max_basis`: the maximum number of basis functions parameters to use for PDFs\n",
@@ -357,9 +357,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now use this data to train our model using the `FlexZBoostInformer`.  `FlexZBoost` uses xgboost to determine a conditional density estimate model, and also fits a `bump_thresh` parameter that erases small peaks that are an artifact of the `cosine` parameterization.  It then finds a best fit `sharpen` parameter that modulates the peaks with a power law.\n",
+    "`FlexZBoostInformer` operates on the training set and writes a file containing the estimation model.  `FlexZBoost` uses xgboost to determine a conditional density estimate model, and also fits the `bump_thresh` and `sharpen` parameters described above.\n",
     "\n",
-    "`FlexZBoost` is a bit more sophisticated than the earlier k-nearest neighbor estimator, so it will take a bit longer to train, but not drastically so.  We specified the name of the model file, `demo_FZB_model.pkl`, which will store our trained model for use with the estimation stage."
+    "`FlexZBoost` is a bit more sophisticated than the earlier k-nearest neighbor estimator, so it will take a bit longer to train, but not drastically so, still under a minute on a semi-new laptop.  We specified the name of the model file, `demo_FZB_model.pkl`, which will store our trained model for use with the estimation stage."
    ]
   },
   {
@@ -383,9 +383,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That took slightly longer to train, but still under a minute on a semi-new laptop.  If we have an existing pretrained model, for example the one in the file `demo_FZB_model.pkl` we can skip this step in subsequent runs of estimate: that is, we load this pickled model without having to repeat the training stage for this specific training data, and that can save time for larger training sets that would take longer to create the model.\n",
+    "If we have an existing pretrained model, for example the one in the file `demo_FZB_model.pkl`, we can skip this step in subsequent runs of an estimator; that is, we load this pickled model without having to repeat the training stage for this specific training data, and that can save time for larger training sets that would take longer to create the model.\n",
     "\n",
-    "There are two supported model output representations, `interp` (default) and `flexzboost`. Using `interp` will store the output as interpolated y values for a given set of x values, using this approach will require moderately more storage space, but will generally be faster to work with. Using `flexzboost` will store the output weights from Flexcode. This results in a smaller storage size on disk, but will also require additional computation time when working with the results. \n",
+    "There are two supported model output representations, `interp` (default) and `flexzboost`. Using `flexzboost` will store the output basis function weights from FlexCode, resulting in a smaller storage size on disk and giving the user the option to tune the sharpening and bump-removal parameters as a post-processing step. However, if you know that you will be performing operations on PDFs evaluated on a redshift grid that is known before performing the estimation, you can peform that post-processing up front by employing `interp` to store the output as interpolated y values for a given set of x values, requiring more storage space but eliminating the need to evaluate the PDFs upon downstream usage. \n",
     "\n",
     "For additional comparisons of the approaches, see the documentation for `qp_flexzboost` here: https://qp-flexzboost.readthedocs.io/en/latest/source/performance_comparison.html"
    ]
@@ -419,7 +419,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Yes, only a few seconds.  So, if you are running an algorithm with a burdensome training requirement, saving a trained copy of the model for later repeated use can be a real time saver."
+    "It takes only a few seconds, so, if you are running an algorithm with a burdensome training requirement, saving a trained copy of the model for later repeated use can be a real time saver."
    ]
   },
   {
@@ -443,7 +443,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can calculate the median and mode values of the PDFs and plot their distribution (the modes are already stored in the ancillary data, but here is an example of computing via qp as well):"
+    "We can calculate the median and mode values of the PDFs and plot their distribution (in this case the modes are already stored in the qp.Ensemble's ancillary data, but here is an example of computing the point estimates via qp directly):"
    ]
   },
   {
@@ -471,7 +471,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can plot an example PDF from the results file:"
+    "We can plot an example PDF, its median redshift, and its true redshift from the results file:"
    ]
   },
   {
@@ -496,7 +496,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also plot a few point estimates to make sure our algorithm worked properly, we can compute the median of the PDF trivially and plot against true redshift:"
+    "We can also plot a point estimaten against the truth as a visual diagnostic:"
    ]
   },
   {
@@ -510,14 +510,14 @@
     "plt.plot([0,3],[0,3],'r--')\n",
     "plt.xlabel(\"true redshift\")\n",
     "plt.ylabel(\"photoz mode\")\n",
-    "plt.title(\"median point estimate for FlexZBoost\");"
+    "plt.title(\"mode point estimate derived from FlexZBoost PDFs\");"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The results look very good! FlexZBoost is a mature algorithm, and with representative training data we see a very tight correlation with true redshift and few outliers.<br>"
+    "The results look very good! FlexZBoost is a mature algorithm, and with representative training data we see a very tight correlation with true redshift and few outliers due to physical degeneracies.<br>"
    ]
   }
  ],

--- a/examples/estimation_examples/RAIL_estimation_demo.ipynb
+++ b/examples/estimation_examples/RAIL_estimation_demo.ipynb
@@ -117,7 +117,7 @@
     "## The code-specific parameters\n",
     "Each photo-z algorithm has code-specific parameters necessary to initialize the code.  These values can be input on the command line, or passed in via a dictionary.<br>\n",
     "\n",
-    "Let's start with a very simple demonstration using `k_nearneigh`, a RAIL wrapper around `sklearn`'s nearest neighbor method.  It calculates a normalized weight for the K nearest neighbors based on their distance and makes a PDF as a sum of K Gaussians, each at the redshift of the training galaxy with amplitude based on the distance weight, and a Gaussian width set by the user.  This is a toy model estimator, but it actually performs very well for representative data sets. There are configuration parameters for the names of columns, random seeds, etc... in `KNearNeighEstimator` with best-guess sensible defaults based on preliminary experimentation in DESC. See the [KNearNeigh code](https://github.com/LSSTDESC/RAIL/blob/eac-dev/rail/estimation/algos/k_nearneigh.py) for more details, but here is a minimal set to run:"
+    "Let's start with a very simple demonstration using `k_nearneigh`, a RAIL wrapper around `sklearn`'s nearest neighbor (NN) method.  It calculates a normalized weight for the K nearest neighbors based on their distance and makes a PDF as a sum of K Gaussians, each at the redshift of the training galaxy with amplitude based on the distance weight, and a Gaussian width set by the user.  This is a toy model estimator, but it actually performs very well for representative data sets. There are configuration parameters for the names of columns, random seeds, etc... in `KNearNeighEstimator` with best-guess sensible defaults based on preliminary experimentation in DESC. See the [KNearNeigh code](https://github.com/LSSTDESC/RAIL/blob/eac-dev/rail/estimation/algos/k_nearneigh.py) for more details, but here is a minimal set to run:"
    ]
   },
   {
@@ -135,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, `trainfrac` sets the amount of training data to use in training the algorithm.  The remaining fraction is used to validate two quantities, the width of the Gaussians used in constructing the PDF, and the number of neighbors used in each PDF.  The CDE Loss is computed on a grid of width and number of neighbors (NN), and the combination of width and NN with the lowest CDE loss is used.  `sigma_grid_min`, `sigma_grid_max`, and `ngrid_sigma` are used to specify the grid of sigma values to test, while `nneigh_min` and `nneigh_max` are the integer values between which we will check the loss.\n",
+    "Here, `trainfrac` sets the proportion of training data to use in training the algorithm, where the remaining fraction is used to validate both the width of the Gaussians used in constructing the PDF and the number of neighbors used in each PDF.  The CDE Loss is a metric computed on a grid of some width and number of neighbors `NN`, and the combination of width and `NN` with the lowest CDE loss is used.  `sigma_grid_min`, `sigma_grid_max`, and `ngrid_sigma` are used to specify the grid of sigma values to test, while `nneigh_min` and `nneigh_max` are the integer values between which we will check the loss.\n",
     "\n",
     "`zmin`, `zmax`, and `nzbins` are used to create a grid on which the CDE Loss is computed when minimizing the loss to find the best values for sigma and number of neighbors to use."
    ]
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will begin by training the algorithm, to to this we instantiate a rail object with a call to the base class.\n",
+    "We will begin by training the algorithm by instantiating its `Informer` stage.\n",
     "\n",
     "If any essential parameters are missing from the parameter dictionary, they will be set to default values:"
    ]
@@ -163,7 +163,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's load our training data, which is stored in hdf5 format.  We'll load it into the Data Store so that the ceci stages are able to access it."
+    "Now, let's load our training data, which is stored in the hdf5 format.  We'll load it into the `DataStore` so that the `ceci` stages are able to access it."
    ]
   },
   {
@@ -183,9 +183,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to train the KDTree, which is done with the `inform` function present in every RAIL/estimation code. The parameter `model` is the name that the trained model object will be saved as in pickle format, in this case `demo_knn.pkl`.  In the future, rather than re-run a potentially time consuming training set, we can simply load this pickle file before we run the estimate stage.\n",
+    "We need to train the KDTree, which is done with the `inform()` method present in every `Informer` stage. The parameter `model` is the name that the trained model object that will be saved in a format specific to the estimation algorithm in question, in this case in the default pickle format as `demo_knn.pkl`. \n",
     "\n",
-    "KNearNeighEstimator.inform finds the best sigma and NNeigh and stores those along with the KDTree in the model."
+    "KNearNeighInformer.inform finds the best sigma and NNeigh and stores those along with the KDTree in the model."
    ]
   },
   {
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now set up the main photo-z stage and run our algorithm on the data to produce simple photo-z estimates.  Note that we are loading the trained model that we computed from the inform stage:"
+    "We can now set up the main photo-z `Estimator` stage and run our algorithm on the data to produce simple photo-z estimates.  Note that we are loading the trained model that we computed from the `Informer` stage:"
    ]
   },
   {
@@ -220,7 +220,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output file is a qp Ensemble containing the redshift PDFs.  The Ensemble also includes the modes of the PDFs.  The modes are stored in the \"ancillary\" data within qp.  By default it will be in an 1xM array, so you may need to include a `.flatten()` to flatten the array.  The zmode values in the ancillary data can be accessed via:"
+    "The output file is a `qp.Ensemble` containing the redshift PDFs.  This `Ensemble` also includes a photo-z point estimate derived from the PDFs, the mode by default (though there will soon be a keyword option to choose a different point estimation method or to skip the calculation of a point estimate).  The modes are stored in the \"ancillary\" data within the `Ensemble`.  By default it will be in an 1xM array, so you may need to include a `.flatten()` to flatten the array.  The zmode values in the ancillary data can be accessed via:"
    ]
   },
   {
@@ -256,7 +256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Not bad, given our very simple estimator.  For the PDFs, KNearNeighEstimator is storing a mixture model parameterization where the PDF is represented by a set of N Gaussians for each galaxy.  As qp Ensembles are built upon scipy.stats infrastructure, we can evaluate the PDF on a set of grid points with the built-in `.pdf` method.  Let's pick a single galaxy from our sample, evaluate the PDF, and plot, along with the value of the mode and the true redshift:"
+    "Not bad, given our very simple estimator!  For the PDFs, `KNearNeigh` is storing each PDF as a Gaussian mixture model parameterization where each PDF is represented by a set of N Gaussians for each galaxy.  `qp.Ensemble` objects have all the methods of `scipy.stats.rv_continuous` objects so we can evaluate the PDF on a set of grid points with the built-in `.pdf` method.  Let's pick a single galaxy from our sample and evaluate and plot the PDF, the mode, and true redshift:"
    ]
   },
   {

--- a/examples/estimation_examples/RAIL_estimation_demo.ipynb
+++ b/examples/estimation_examples/RAIL_estimation_demo.ipynb
@@ -8,26 +8,20 @@
     "\n",
     "author: Sam Schmidt, Eric Charles, others...\n",
     "\n",
-    "last run successfully: April 26, 2023"
+    "last run successfully: August 4, 2023"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(FIXME, workaround for bug in mixmod PDF triggered in new version of scipy)\n",
-    "\n",
     "This is a notebook demonstrating some of the features of the LSSTDESC `RAIL` package, namely the features of `estimation`.  \n",
     "\n",
-    "`RAIL/estimation` is the interface for running production level photo-z codes within DESC.  There is a minimimal superclass that sets up some file paths and variable names, each specific photo-z code resides in a subclass with code-specific setup variables.\n",
+    "`RAIL/estimation` is the interface for running production level photo-z codes within DESC.  There is a minimimal superclass that sets up some file paths and variable names, each specific photo-z code resides in a subclass with code-specific setup variables.  More extensive documentation is available on Read the Docs here:\n",
+    "https://rail-hub.readthedocs.io/en/latest/\n",
     "\n",
-    "RAIL is available at:\n",
-    "\n",
-    "https://github.com/LSSTDESC/RAIL\n",
-    "\n",
-    "and must be installed and included in your python path to work.  The LSSTDESC `qp` package that handles PDF files is also required, it is available at:\n",
-    "\n",
-    "https://github.com/LSSTDESC/qp"
+    "The source code for RAIL is available on GitHub at:\n",
+    "https://github.com/LSSTDESC/RAIL"
    ]
   },
   {
@@ -58,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll start by setting up the Rail data store.  RAIL uses [ceci](https://github.com/LSSTDESC/ceci), which is designed for pipelines rather than interactive notebooks, the data store will work around that and enable us to use data interactively.  This is a slight hack, and we will have some files appearing in the data store with the prefix \"inprogress_\" as they are stored in memory.  See the `RAIL/examples/goldenspike_examples/goldenspike.ipynb` example notebook for more details on the Data Store."
+    "We'll start by setting up the Rail data store.  RAIL uses [ceci](https://github.com/LSSTDESC/ceci), which is designed for pipelines rather than interactive notebooks, the data store will work around that and enable us to use data interactively.   Some files will appear in the data store with the prefix \"inprogress_\" as they are stored in memory for use in the notebook, but the data will also be written out to file.  See the `RAIL/examples/goldenspike_examples/goldenspike.ipynb` example notebook for more details on the Data Store."
    ]
   },
   {
@@ -75,9 +69,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Getting the list of available Estimators\n",
+    "### Importing all available estimators\n",
     "\n",
-    "RailStage knows about all of the sub-types of stages.  The are stored in the `RailStage.pipeline_stages` dict.  By looping through the values in that dict we can and asking if each one is a sub-class of `rail.estimation.estimator.CatEstimator` we can identify the available estimators that operator on catalog-like inputs."
+    "There is some handy functionality in `rail.stages` to import all available stages that are installed in your environment.  RailStage knows about all of the sub-types of stages.  The are stored in the `RailStage.pipeline_stages` dict.  By looping through the values in that dict we can and asking if each one is a sub-class of `rail.estimation.estimator.CatEstimator` we can identify the available estimators that operator on catalog-like inputs.  Let's run this `import_and_attach_all()` command, and then print out the subclasses that are now available for use (though in this demo we only take advantage of two specific estimators):"
    ]
   },
   {
@@ -98,20 +92,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You should see a list of the available photo-z algorithms, as printed out above.  These are the names of the specific subclasses that invoke a particular method, and they are stored in the `rail.estimation.algos` subdirectory of RAIL.\n",
+    "You should see a list of the available photo-z algorithms, as printed out above.  These are the names of the specific subclasses that invoke a particular method, and currently include:\n",
     "\n",
-    "- `Randompz` is a very simple class that does not actually predict a meaningful photo-z, instead it produces a randomly drawn Gaussian for each galaxy.\n",
-    "- `trainZ` is our \"pathological\" estimator, it makes a PDF from a histogram of the training data and assigns that PDF to every galaxy.\n",
-    "- `simpleNN` uses `sklearn`'s neural network to predict a point redshift from the training data, then assigns a sigma width based on the redshift, another toy model example.\n",
-    "- `FlexZBoost` is a fully functional photo-z algorithm, implementing the FlexZBoost conditional density estimate method that was used in the PhotoZDC1 paper.  FlexZBoost has been moved to its own GitHub repo, and is available in the [rail_flexzboost](https://github.com/LSSTDESC/rail_flexzboost/) repo.\n",
-    "- `BPZ_lite` is a template-based code that outputs the posterior estimated given a specific template set and Bayesian prior. See Benitez (2000) for more details.\n",
-    "- `delight_hybrid` is a hybrid gaussian process/template-based code, see the [Delight](https://github.com/LSSTDESC/Delight) repo for more details.\n",
+    "- `BPZliteEstimator` is a template-based code that outputs the posterior estimated given a specific template set and Bayesian prior. See Benitez (2000) for more details.\n",
+    "- `CMNNEstimator` is an implementation of the \"colour-matched nearest neighbour` estimator described in [Graham et al 2018](https://ui.adsabs.harvard.edu/abs/2018AJ....155....1G/abstract).  It returns a single Gaussian for each galaxy.\n",
+    "- `DelightEstimator` is a hybrid gaussian process/template-based code, see the [Delight](https://github.com/LSSTDESC/Delight) repo for more details.\n",
+    "- `FlexZBoostEstimator` is a fully functional photo-z algorithm, implementing the FlexZBoost conditional density estimate method that was used in the PhotoZDC1 paper.  FlexZBoost has been moved to its own GitHub repo, and is available in the [rail_flexzboost](https://github.com/LSSTDESC/rail_flexzboost/) repo.\n",
+    "- `GPzEstimator` is a Gaussian Process-based estimator, see [Almosallam et al 2016](https://ui.adsabs.harvard.edu/abs/2016MNRAS.462..726A/abstract) for details on the algorithm.  It currently returns a single Gaussian for each PDF.\n",
     "- `KNearNeighEstimator` is a simple implementation of a weighted k-nearest neighbor photo-z code, it stores each PDF as a weighted sum of Gaussians based on the distance from neighbors in color space.<br>\n",
     "- `PZFlowEstimator` uses the same normalizing flow code [pzflow](https://github.com/jfcrenshaw/pzflow) used in the `creation` module to predict redshift PDFs.\n",
+    "- `RandomGaussEstimator` is a very simple class that does not actually predict a meaningful photo-z, instead it produces a randomly drawn Gaussian for each galaxy.\n",
+    "- `SklNeurNetEstimator` uses `sklearn`'s neural network to predict a point redshift from the training data, then assigns a sigma width based on the redshift, another toy model example.\n",
+    "- `TrainZEstimator` is our \"pathological\" estimator, it makes a PDF from a histogram of the training data and assigns that PDF to every galaxy.\n",
     "\n",
-    "Each code should have two specific classes associated with it: one to train/inform using a set of training data, and a second to actually estimate the photo-z PDFs.  These should be imported from the `src/rail/estimation/algos/[name_of_code].py` module (not exactly the package name to avoid namespace collisions). The naming pattern is `[NameOfCode]Estimator` for the estimating class, and `[NameOfCode]Informer` for the training/ingesting class, for example `FlexZBoostEstimator` and  `FlexZBoostInformer`.  \n",
     "\n",
-    "The ceci code base will have us using a pattern where we will first run a `make_stage` method for the class in order to set up the ceci infrastructure.  Each `Inform_[name]` class will have a function called `inform` that actually performs the training.  Similarly, every `[photoz name]` class will have an `estimate` function to compute the PDFs.  We will show examples of this below.\n"
+    "Each code should have two specific classes associated with it: one to train/inform using a set of training data, and a second to actually estimate the photo-z PDFs.  These should be imported from the `src/rail/estimation/algos/[name_of_code].py` module. The naming pattern is `[NameOfCode]Estimator` for the estimating class, and `[NameOfCode]Informer` for the training/ingesting class, for example `FlexZBoostEstimator` and  `FlexZBoostInformer`.  \n",
+    "\n",
+    "The ceci code base will have us using a pattern where we will first run a `make_stage` method for the class in order to set up the ceci infrastructure.  Each `[name]Informer` class will have a function called `inform` that actually performs the training.  Similarly, every `[photoz name]Estimator` class will have an `estimate` function to compute the PDFs.  We will show examples of this below."
    ]
   },
   {
@@ -139,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, `trainfrac` sets the amount of training data to use in training the algorithm.  The remaining fraction is used to validate two quantities, the width of the Gaussians used in constructing the PDF, and the number of neighbors used in each PDF.  The CDE Loss is computed on a grid of width and NN values, and the combination of width and NN with the lowest CDE loss is used.  `sigma_grid_min`, `sigma_grid_max`, and `ngrid_sigma` are used to specify the grid of sigma values to test, while `nneigh_min` and `nneigh_max` are the integer values between which we will check the loss.\n",
+    "Here, `trainfrac` sets the amount of training data to use in training the algorithm.  The remaining fraction is used to validate two quantities, the width of the Gaussians used in constructing the PDF, and the number of neighbors used in each PDF.  The CDE Loss is computed on a grid of width and number of neighbors (NN), and the combination of width and NN with the lowest CDE loss is used.  `sigma_grid_min`, `sigma_grid_max`, and `ngrid_sigma` are used to specify the grid of sigma values to test, while `nneigh_min` and `nneigh_max` are the integer values between which we will check the loss.\n",
     "\n",
     "`zmin`, `zmax`, and `nzbins` are used to create a grid on which the CDE Loss is computed when minimizing the loss to find the best values for sigma and number of neighbors to use."
    ]
@@ -187,7 +184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to train the KDTree, which is done with the `inform` function present in every RAIL/estimation code. The parameter `model` is the name that the trained model object will be saved in pickle format, in this case `demo_knn.pkl`.  In the future, rather than re-run a potentially time consuming training set, we can simply load this pickle file before we run the estimate stage.\n",
+    "We need to train the KDTree, which is done with the `inform` function present in every RAIL/estimation code. The parameter `model` is the name that the trained model object will be saved as in pickle format, in this case `demo_knn.pkl`.  In the future, rather than re-run a potentially time consuming training set, we can simply load this pickle file before we run the estimate stage.\n",
     "\n",
     "KNearNeighEstimator.inform finds the best sigma and NNeigh and stores those along with the KDTree in the model."
    ]
@@ -224,7 +221,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output file is a dictionary containing the redshift PDFs and the mode of the PDFs.  The modes are stored in the \"ancillary\" data within qp, and can be accessed via:"
+    "The output file is a qp Ensemble containing the redshift PDFs.  The Ensemble also includes the modes of the PDFs.  The modes are stored in the \"ancillary\" data within qp.  By default it will be in an 1xM array, so you may need to include a `.flatten()` to flatten the array.  The zmode values in the ancillary data can be accessed via:"
    ]
   },
   {
@@ -233,19 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zmode = results().ancil['zmode']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# The mode computation for mix_mod pdf is broken with the new scipy, but we can get easily\n",
-    "# get the peak of the largest contributor\n",
-    "whichone = np.argmax(results().dist.weights, axis=1)\n",
-    "zmode = np.array([means_[whichone_] for means_, whichone_ in zip(results().dist.means, whichone)])"
+    "zmode = results().ancil['zmode'].flatten()"
    ]
   },
   {
@@ -272,7 +257,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Not bad, given our very simple estimator.  For the PDFs, the simpleNN is storing a gridded parameterization where the PDF is evaluated at a fixed set of redshifts for each galaxy.  That grid is stored in `pz.zgrid`, and we'll need that to plot.  Remember that our simple Neural Net just estimated a point photo-z then assumed a Gaussian, so all PDFs will be of that simple form.  Let's plot an example pdf:"
+    "Not bad, given our very simple estimator.  For the PDFs, KNearNeighEstimator is storing a mixture model parameterization where the PDF is represented by a set of N Gaussians for each galaxy.  As qp Ensembles are built upon scipy.stats infrastructure, we can evaluate the PDF on a set of grid points with the built-in `.pdf` method.  Let's pick a single galaxy from our sample, evaluate the PDF, and plot, along with the value of the mode and the true redshift:"
    ]
   },
   {
@@ -313,7 +298,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## FZBoost"
+    "## FlexZBoost"
    ]
   },
   {
@@ -330,9 +315,9 @@
     "\n",
     "One of the dominant features seen in our PhotoZDC1 analysis of multiple photo-z codes (Schmidt, Malz et al. 2020) was that photo-z estimates were often, in general, overconfident or underconfident in their overall uncertainty in PDFs.  To remedy this, `FlexZBoostEstimator` has an additional post-processing step where it estimates a \"sharpening\" parameter that modulates the width of the PDFs.\n",
     "\n",
-    "A portion of the training data is held in reserve to find best-fit values for both `bump_thresh` and `sharpening`, which we find by simply calculating the CDE loss for a grid of `bump_thresh` and `sharpening` values.\n",
+    "A portion of the training data is held in reserve to find best-fit values for both `bump_thresh` and `sharpening`, which we find by simply calculating the CDE loss for a grid of `bump_thresh` and `sharpening` values, though once those values are set FlexZBoost will re-train its density estimate model with the full dataset.\n",
     "\n",
-    "We'll start with a dictionary of setup parameters for FlexZBoostEstimator, just as we had for the scikit-learn neural network.  Some of the parameters are the same as in `skl_neurnet` above, `zmin`, `zmax`, `nzbins`.  However, FlexZBoostEstimator performs a more in depth training than simpleNN, and as such has more input parameters to control behavior.  These parameters are:\n",
+    "We'll start with a dictionary of setup parameters for FlexZBoostEstimator, just as we had for the k-nearest neighbor estimator.  Some of the parameters are the same as in k-nearest neighbor above, `zmin`, `zmax`, `nzbins`.  However, FlexZBoostEstimator performs a more in depth training than simpleNN, and as such has more input parameters to control behavior.  These parameters are:\n",
     "\n",
     "- `basis_system`: which basis system to use in the density estimate. The default is `cosine` but `fourier` is also an option\n",
     "- `max_basis`: the maximum number of basis functions parameters to use for PDFs\n",
@@ -375,7 +360,7 @@
    "source": [
     "We can now use this data to train our model using the `FlexZBoostInformer`.  `FlexZBoost` uses xgboost to determine a conditional density estimate model, and also fits a `bump_thresh` parameter that erases small peaks that are an artifact of the `cosine` parameterization.  It then finds a best fit `sharpen` parameter that modulates the peaks with a power law.\n",
     "\n",
-    "We have `save_train` set to `True` in our `inform_options`, so this will save a pickled version of the best fit model to the file specified in `inform_options['modelfile']`, which is set above to `demo_FZB_model.pkl`.  We can use the same training data that we used for `skl_neurnet`.  `FlexZBoost` is a bit more sophisticated than `skl_neurnet`, so it will take a bit longer to train (note: it should take about 10-15 minutes on cori for the 10,000 galaxies in our demo sample):"
+    "`FlexZBoost` is a bit more sophisticated than the earlier k-nearest neighbor estimator, so it will take a bit longer to train, but not drastically so.  We specified the name of the model file, `demo_FZB_model.pkl`, which will store our trained model for use with the estimation stage."
    ]
   },
   {
@@ -399,9 +384,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That took quite a while to train! But, if we have an existing pretrained model, for example the one in the file `demo_FZB_model.pkl` we can skip this step in subsequent runs of estimate: that is, we load this pickled model without having to repeat the training stage for this specific training data, and that should be much faster.\n",
+    "That took slightly longer to train, but still under a minute on a semi-new laptop.  If we have an existing pretrained model, for example the one in the file `demo_FZB_model.pkl` we can skip this step in subsequent runs of estimate: that is, we load this pickled model without having to repeat the training stage for this specific training data, and that can save time for larger training sets that would take longer to create the model.\n",
     "\n",
-    "There are two supported model output representations, `interp` (default) and `flexzboost`. Using `interp` will store the output as interpolated y values for a given set of x values, using this approach will require much more storage space, but will generally be faster to work with. Using `flexzboost` will store the output weights from Flexcode. This results in a much smaller storage size on disk, but will also require additional computation time when working with the results. \n",
+    "There are two supported model output representations, `interp` (default) and `flexzboost`. Using `interp` will store the output as interpolated y values for a given set of x values, using this approach will require moderately more storage space, but will generally be faster to work with. Using `flexzboost` will store the output weights from Flexcode. This results in a smaller storage size on disk, but will also require additional computation time when working with the results. \n",
     "\n",
     "For additional comparisons of the approaches, see the documentation for `qp_flexzboost` here: https://qp-flexzboost.readthedocs.io/en/latest/source/performance_comparison.html"
    ]
@@ -553,7 +538,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/examples/estimation_examples/RAIL_estimation_demo.ipynb
+++ b/examples/estimation_examples/RAIL_estimation_demo.ipynb
@@ -93,21 +93,21 @@
    "source": [
     "You should see a list of the available subclasses corresponding to specific photo-z algorithms, as printed out above.  These currently include:\n",
     "\n",
-    "- `BPZliteEstimator` is a template-based code that outputs the posterior estimated given a specific template set and Bayesian prior. See Benitez (2000) for more details.\n",
-    "- `CMNNEstimator` is an implementation of the \"colour-matched nearest neighbour` estimator described in [Graham et al 2018](https://ui.adsabs.harvard.edu/abs/2018AJ....155....1G/abstract).  It returns a single Gaussian for each galaxy.\n",
-    "- `DelightEstimator` is a hybrid gaussian process/template-based code, see the [Delight](https://github.com/LSSTDESC/Delight) repo for more details.\n",
-    "- `FlexZBoostEstimator` is a fully functional photo-z algorithm, implementing the FlexZBoost conditional density estimate method that was used in the PhotoZDC1 paper.  FlexZBoost has been moved to its own GitHub repo, and is available in the [rail_flexzboost](https://github.com/LSSTDESC/rail_flexzboost/) repo.\n",
-    "- `GPzEstimator` is a Gaussian Process-based estimator, see [Almosallam et al 2016](https://ui.adsabs.harvard.edu/abs/2016MNRAS.462..726A/abstract) for details on the algorithm.  It currently returns a single Gaussian for each PDF.\n",
-    "- `KNearNeighEstimator` is a simple implementation of a weighted k-nearest neighbor photo-z code, it stores each PDF as a weighted sum of Gaussians based on the distance from neighbors in color space.<br>\n",
-    "- `PZFlowEstimator` uses the same normalizing flow code [pzflow](https://github.com/jfcrenshaw/pzflow) used in the `creation` module to predict redshift PDFs.\n",
-    "- `RandomGaussEstimator` is a very simple class that does not actually predict a meaningful photo-z, instead it produces a randomly drawn Gaussian for each galaxy.\n",
-    "- `SklNeurNetEstimator` uses `sklearn`'s neural network to predict a point redshift from the training data, then assigns a sigma width based on the redshift, another toy model example.\n",
-    "- `TrainZEstimator` is our \"pathological\" estimator, it makes a PDF from a histogram of the training data and assigns that PDF to every galaxy.\n",
+    "- `bpz_lite` is a template-based code that outputs the posterior estimated given a specific template set and Bayesian prior. See [Benitez (2000)](http://stacks.iop.org/0004-637X/536/i=2/a=571) for more details.\n",
+    "- `cmnn` is an implementation of the \"colour-matched nearest neighbour` estimator described in [Graham et al 2018](https://ui.adsabs.harvard.edu/abs/2018AJ....155....1G/abstract).  It returns a single Gaussian for each galaxy.\n",
+    "- `delight_hybrid` (currently `delightPZ`) is a hybrid gaussian process/template-based code. See the [Leistedt & Hogg (2017)](https://doi.org/10.3847%2F1538-3881%2Faa91d5) for more details.\n",
+    "- `flexzboost` is a fully functional photo-z algorithm, implementing the FlexZBoost conditional density estimate method from [Izbicki, Lee & Freeman (2017)](https://doi.org/10.1214/16-AOAS1013) that performed well in the LSST-DESC Photo-Z Data Challenge 1 paper ([Schmidt, Malz & Soo, et al. (2020)](https://academic.oup.com/mnras/article/499/2/1587/5905416)).  FlexZBoost and some specialized metrics for it are available in Python and R through [FlexCode](https://github.com/lee-group-cmu/FlexCode).\n",
+    "- `gpz` is a Gaussian Process-based estimator. See [Almosallam et al 2016](https://ui.adsabs.harvard.edu/abs/2016MNRAS.462..726A/abstract) for details on the algorithm.  It currently returns a single Gaussian for each PDF.\n",
+    "- `k_nearneigh` is a simple implementation of a weighted k-nearest neighbor photo-z code. It stores each PDF as a weighted sum of Gaussians based on the distance from neighbors in color-space.<br>\n",
+    "- `pzflow_nf` uses the same normalizing flow code [pzflow](https://github.com/jfcrenshaw/pzflow), the same one that appears in `rail.creation`, to predict redshift PDFs.\n",
+    "- `random_gauss` is a very simple class that does not actually predict a meaningful photo-z but can be useful for quick null tests when developing a pipeline. Instead it produces a randomly drawn Gaussian for each galaxy.\n",
+    "- `sklearn_neurnet` is another toy model using `sklearn`'s neural network to predict a point estimate redshift from the training data, then assigns a sigma width based on the estimated redshift.\n",
+    "- `trainz` is our \"pathological\" estimator. It makes a PDF from a histogram of the training data and assigns that PDF to every galaxy without considering its photometry.\n",
     "\n",
     "\n",
-    "Each code should have two specific classes associated with it: one to train/inform using a set of training data, and a second to actually estimate the photo-z PDFs.  These should be imported from the `src/rail/estimation/algos/[name_of_code].py` module. The naming pattern is `[NameOfCode]Estimator` for the estimating class, and `[NameOfCode]Informer` for the training/ingesting class, for example `FlexZBoostEstimator` and  `FlexZBoostInformer`.  \n",
+    "Each code should have two specific classes associated with it: one to `inform()` using a set of training data or explicit priors and one to `estimate()` the per-galaxy photo-z PDFs.  These should be imported from the `src/rail/estimation/algos/[name_of_code]` module using the above names. The naming pattern is `[NameOfCode]Estimator` for the estimating class, and `[NameOfCode]Informer` for the training/ingesting class, for example `FlexZBoostEstimator` and  `FlexZBoostInformer`.  \n",
     "\n",
-    "The ceci code base will have us using a pattern where we will first run a `make_stage` method for the class in order to set up the ceci infrastructure.  Each `[name]Informer` class will have a function called `inform` that actually performs the training.  Similarly, every `[photoz name]Estimator` class will have an `estimate` function to compute the PDFs.  We will show examples of this below."
+    "For each of these two classes, we follow the pattern to first run a `make_stage()` method for the class in order to set up the `ceci` infrastructure and then invoke the `inform()` or `estimate()` method for the class in question.  We show examples of this below."
    ]
   },
   {
@@ -115,9 +115,9 @@
    "metadata": {},
    "source": [
     "## The code-specific parameters\n",
-    "Each photo-z code will have code-specific parameters necessary to initialize the code.  These values can be input on the command line, or passed in via a dictionary.<br>\n",
+    "Each photo-z algorithm has code-specific parameters necessary to initialize the code.  These values can be input on the command line, or passed in via a dictionary.<br>\n",
     "\n",
-    "Let's start with a very simple demonstration using `KNearNeighEstimator`.  `KNearNeighEstimator` is just `sklearn`'s nearest neighbor method run on the training data and set up within the RAIL interface.  It calculates a normalized weight for the K nearest neighbors based on their distance, and makes a PDF as a sum of K Gaussians, each at the redshift of the training galaxy with amplitude based on the distance weight, and a Gaussian width set by the user.  This is a toy model estimator, but it actually performs very well for representative data sets. There are configuration parameters for the names of columns, random seeds, etc... in KNearNeighEstimator, but they are assigned sensible defaults, see the [KNearNeigh code](https://github.com/LSSTDESC/RAIL/blob/eac-dev/rail/estimation/algos/k_nearneigh.py) for more details, but here is a minimal set to run:"
+    "Let's start with a very simple demonstration using `k_nearneigh`, a RAIL wrapper around `sklearn`'s nearest neighbor method.  It calculates a normalized weight for the K nearest neighbors based on their distance and makes a PDF as a sum of K Gaussians, each at the redshift of the training galaxy with amplitude based on the distance weight, and a Gaussian width set by the user.  This is a toy model estimator, but it actually performs very well for representative data sets. There are configuration parameters for the names of columns, random seeds, etc... in `KNearNeighEstimator` with best-guess sensible defaults based on preliminary experimentation in DESC. See the [KNearNeigh code](https://github.com/LSSTDESC/RAIL/blob/eac-dev/rail/estimation/algos/k_nearneigh.py) for more details, but here is a minimal set to run:"
    ]
   },
   {

--- a/examples/estimation_examples/RAIL_estimation_demo.ipynb
+++ b/examples/estimation_examples/RAIL_estimation_demo.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "author: Sam Schmidt, Eric Charles, Alex Malz, others...\n",
     "\n",
-    "last run successfully: August 4, 2023"
+    "last run successfully: August 15, 2023"
    ]
   },
   {
@@ -19,8 +19,7 @@
     "\n",
     "The `rail.estimation` subpackage contains infrastructure to run multiple production-level photo-z codes.  There is a minimimal superclass that sets up some file paths and variable names. Each specific photo-z code resides in a subclass in `rail.estimation.algos` with algorithm-specific setup variables.  More extensive documentation is available on Read the Docs here:\n",
     "https://rail-hub.readthedocs.io/en/latest/\n",
-    "\n",
-    ""
+    "\n"
    ]
   },
   {
@@ -135,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, `trainfrac` sets the proportion of training data to use in training the algorithm, where the remaining fraction is used to validate both the width of the Gaussians used in constructing the PDF and the number of neighbors used in each PDF.  The CDE Loss is a metric computed on a grid of some width and number of neighbors `NN`, and the combination of width and `NN` with the lowest CDE loss is used.  `sigma_grid_min`, `sigma_grid_max`, and `ngrid_sigma` are used to specify the grid of sigma values to test, while `nneigh_min` and `nneigh_max` are the integer values between which we will check the loss.\n",
+    "Here, `trainfrac` sets the proportion of training data to use in training the algorithm, where the remaining fraction is used to validate both the width of the Gaussians used in constructing the PDF and the number of neighbors used in each PDF.  The CDE Loss is a metric computed on a grid of some width and number of neighbors, and the combination of width and number of neighbors with the lowest CDE loss is used.  `sigma_grid_min`, `sigma_grid_max`, and `ngrid_sigma` are used to specify the grid of sigma values to test, while `nneigh_min` and `nneigh_max` are the integer values between which we will check the loss.\n",
     "\n",
     "`zmin`, `zmax`, and `nzbins` are used to create a grid on which the CDE Loss is computed when minimizing the loss to find the best values for sigma and number of neighbors to use."
    ]
@@ -163,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's load our training data, which is stored in the hdf5 format.  We'll load it into the `DataStore` so that the `ceci` stages are able to access it."
+    "Now, let's load our training data, which is stored in hdf5 format.  We'll load it into the `DataStore` so that the `ceci` stages are able to access it."
    ]
   },
   {
@@ -183,9 +182,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to train the KDTree, which is done with the `inform()` method present in every `Informer` stage. The parameter `model` is the name that the trained model object that will be saved in a format specific to the estimation algorithm in question, in this case in the default pickle format as `demo_knn.pkl`. \n",
+    "We need to train the KDTree, which is done with the `inform()` method present in every `Informer` stage. The parameter `model` is the name that the trained model object that will be saved as, in a format specific to the estimation algorithm in question.  In this case the format is a pickle file called `demo_knn.pkl`. \n",
     "\n",
-    "KNearNeighInformer.inform finds the best sigma and NNeigh and stores those along with the KDTree in the model."
+    "`KNearNeighInformer.inform` finds the best sigma and NNeigh and stores those along with the KDTree in the model."
    ]
   },
   {
@@ -310,7 +309,7 @@
     "\n",
     "on the command line or from source.  Once installed, it will function the same as any of the other estimators included in the primary `rail` repo.\n",
     "\n",
-    "`FlexZBoostEstimator` approximates the conditional density estimate for each PDF with a set of weights on a set of basis functions.  This can save space relative to a gridded parameterization, but it also sometimes leads to residual \"bumps\" in the PDF from the underlying parameterization.  For this reason, `FlexZBoostEstimator` has a post-processing stage where it \"trims\" (i.e. sets to zero) any small peaks, or \"bumps\", below a certain `bump_thresh` threshold.\n",
+    "`FlexZBoostEstimator` approximates the conditional density estimate for each PDF with a set of weights on a set of basis functions.  This can save space relative to a gridded parameterization, but it also leads to residual \"bumps\" in the PDF intrinsic to the underlying cosine or fourier parameterization.  For this reason, `FlexZBoostEstimator` has a post-processing stage where it \"trims\" (i.e. sets to zero) any small peaks, or \"bumps\", below a certain `bump_thresh` threshold.\n",
     "\n",
     "One of the dominant features seen in our PhotoZDC1 analysis of multiple photo-z codes (Schmidt, Malz et al. 2020) was that photo-z estimates were often, in general, overconfident or underconfident in their overall uncertainty in PDFs.  To remedy this, `FlexZBoostEstimator` has an additional post-processing step where it applies a \"sharpening\" parameter `sharpen` that modulates the width of the PDFs according to a power law.\n",
     "\n",


### PR DESCRIPTION
This is the first pass through the notebook, I fully expect several suggestions from Olivia and Alex.  The first pass was to just remove the blatantly out of date and incorrect info.

For example, the `rail.stages.import_and_attach_all()` may be out of place here, or there may be a better illustration of how to load things, opinions and suggested changes would be great.