### PR TITLE
Forgotten RTD update

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,15 +2,13 @@
 RAIL: Redshift Assessment Infrastructure Layers
 ===============================================
 
-The LSST-DESC Redshift Assessment Infrastructure Layer (RAIL) code is a framework to perform photometric redshift (PZ) estimation and analysis for DESC.
+RAIL is a flexible open-source software library providing tools to produce at-scale photometric redshift data products, including uncertainties and summary statistics, and stress-test them under realistically complex systematics.
 
-RAIL's purpose is to be the infrastructure enabling the PZ working group deliverables in `the LSST-DESC Science Roadmap (see Sec. 4.14) <https://lsstdesc.org/assets/pdf/docs/DESC_SRM_latest.pdf>`_,
-aiming to guide the selection and implementation of redshift estimators in DESC pipelines.
-RAIL differs from previous plans for PZ pipeline infrastructure in that it is broken into stages,
-each corresponding to a manageable unit of infrastructure advancement, a specific question to answer with that code, and a guaranteed publication opportunity.
-RAIL uses `qp <https://github.com/LSSTDESC/qp>`_ as a back-end for handling univariate probability density functions (PDFs) such as photo-z posteriors or :math:`n(z)` samples.
+RAIL serves as the infrastructure supporting many extragalactic applications of `the Legacy Survey of Space and Time (LSST) <https://www.lsst.org/>`_ on `the Vera C. Rubin Observatory<https://rubinobservatory.org/>`_, including Rubin-wide commissioning activities. 
+RAIL was initiated by the Photometric Redshifts (PZ) Working Group (WG) of the `LSST Dark Energy Science Collaboration (DESC) <https://lsstdesc.org/>`_ as a result of the lessons learned from the `Data Challenge 1 (DC1) experiment <https://academic.oup.com/mnras/article/499/2/1587/5905416>`_ to enable the PZ WG Deliverables in the `LSST-DESC Science Roadmap (see Sec. 5.18) <https://lsstdesc.org/assets/pdf/docs/DESC_SRM_latest.pdf>`_, aiming to guide the selection and implementation of redshift estimators in DESC analysis pipelines.
 
-The RAIL source code is publically available at https://github.com/LSSTDESC/RAIL.
+RAIL is developed and maintained by a diverse team comprising DESC Pipeline Scientists (PSs), international in-kind contributors, LSST Interdisciplinary Collaboration for Computing (LINCC) Frameworks software engineers, and other volunteers, but all are welcome to join the team regardless of LSST data rights. 
+To get involved, chime in on the issues in any of the RAIL repositories described in the Overview section.
 
 
 .. toctree::


### PR DESCRIPTION
This got lost in the migration from [@OliviaLynn's old fork](https://github.com/OliviaLynn/RAIL). The content of index.rst is the most visible thing on RTD but was in source/index_body.rst there instead of index.rst so didn't get propagated when the structure changed.