### PR TITLE
Update README.md - change RTD links to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 [![PyPI](https://img.shields.io/pypi/v/hub?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/pz-rail/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7017551.svg)](https://doi.org/10.5281/zenodo.7017551)
-
 [![Template](https://img.shields.io/badge/Template-RAIL%20Python%20Project%20Template-brightgreen)](https://github.com/LSSTDESC/RAIL-project-template)
-[![Read the Docs](https://img.shields.io/readthedocs/rail-hub)](https://rail-hub.readthedocs.io/en/stable/index.html)
+[![Read the Docs](https://img.shields.io/readthedocs/rail-hub)](https://rail-hub.readthedocs.io/en/latest/index.html)
 
 # RAIL: Redshift Assessment Infrastructure Layers
 
 RAIL is a flexible software library providing tools to produce at-scale photometric redshift data products, including uncertainties and summary statistics, and stress-test them under realistically complex systematics.
-A detailed description of RAIL's modular structure is available in the [Overview](https://rail-hub.readthedocs.io/en/stable/source/overview.html) on ReadTheDocs.
+A detailed description of RAIL's modular structure is available in the [Overview](https://rail-hub.readthedocs.io/en/latest/source/overview.html) on ReadTheDocs.
 
 RAIL serves as the infrastructure supporting many extragalactic applications of the Legacy Survey of Space and Time (LSST) on the Vera C. Rubin Observatory, including Rubin-wide commissioning activities. 
 RAIL was initiated by the Photometric Redshifts (PZ) Working Group (WG) of the LSST Dark Energy Science Collaboration (DESC) as a result of the lessons learned from the [Data Challenge 1 (DC1) experiment](https://academic.oup.com/mnras/article/499/2/1587/5905416) to enable the PZ WG Deliverables in [the LSST-DESC Science Roadmap (see Sec. 5.18)](https://lsstdesc.org/assets/pdf/docs/DESC_SRM_latest.pdf), aiming to guide the selection and implementation of redshift estimators in DESC analysis pipelines.
@@ -17,11 +16,11 @@ RAIL is developed and maintained by a diverse team comprising DESC Pipeline Scie
 
 ## Installation
 
-Installation instructions are available under [Installation](https://rail-hub.readthedocs.io/en/stable/source/installation.html) on ReadTheDocs.
+Installation instructions are available under [Installation](https://rail-hub.readthedocs.io/en/latest/source/installation.html) on ReadTheDocs.
 
 ## Contributing
 
-The greatest strength of RAIL is its extensibility; those interested in contributing to RAIL should start by consulting the [Contributing guidelines](https://rail-hub.readthedocs.io/en/stable/source/contributing.html) on ReadTheDocs.
+The greatest strength of RAIL is its extensibility; those interested in contributing to RAIL should start by consulting the [Contributing guidelines](https://rail-hub.readthedocs.io/en/latest/source/contributing.html) on ReadTheDocs.
 
 ## Citing RAIL
 
@@ -29,4 +28,4 @@ RAIL is open source and may be used according to the terms of its [LICENSE](http
 If you make use of the ideas or software here in any publication, you must cite this repository <https://github.com/LSSTDESC/RAIL> as "LSST-DESC PZ WG (in prep)" with the [Zenodo DOI](https://doi.org/10.5281/zenodo.7017551).
 Please consider also inviting the developers as co-authors on publications resulting from your use of RAIL by [making an issue](https://github.com/LSSTDESC/rail/issues/new/choose).
 Additionally, several of the codes accessible through the RAIL ecosystem must be cited if used in a publication.
-A convenient list of what to cite may be found under [Citing RAIL](https://rail-hub.readthedocs.io/en/stable/source/citing.html) on ReadTheDocs.
+A convenient list of what to cite may be found under [Citing RAIL](https://rail-hub.readthedocs.io/en/latest/source/citing.html) on ReadTheDocs.


### PR DESCRIPTION
Changing the ReadTheDocs links in the readme to latest, rather than stable.

The default version on RTD was already set to latest.