### PR TITLE
switched to find_rail_file from RAILDIR as much as possible

### DIFF
--- a/examples/core_examples/Build_Save_Load_Run_Pipeline.ipynb
+++ b/examples/core_examples/Build_Save_Load_Run_Pipeline.ipynb
@@ -94,11 +94,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
+    "from rail.core.utils import find_rail_file\n",
     "\n",
-    "flow_file = os.path.join(\n",
-    "    RAILDIR, \"rail/examples_data/goldenspike_data/data/pretrained_flow.pkl\"\n",
-    ")\n",
+    "flow_file = find_rail_file(\"examples_data/goldenspike_data/data/pretrained_flow.pkl\")\n",
     "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
     "band_dict = {band: f\"mag_{band}_lsst\" for band in bands}\n",
     "rename_dict = {f\"mag_{band}_lsst_err\": f\"mag_err_{band}_lsst\" for band in bands}\n",

--- a/examples/core_examples/FileIO_DataStore.ipynb
+++ b/examples/core_examples/FileIO_DataStore.ipynb
@@ -60,9 +60,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "\n",
     "traindata_io = tables_io.read(trainFile)[\"photometry\"]"
    ]
@@ -368,6 +368,13 @@
    "source": [
     "That's about it.  For more usages, including how to chain together multiple stages, feeding results one into the other with the DataStore names, see goldenspike.ipynb in the examples/goldenspike directory."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -386,7 +393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/core_examples/FluxtoMag_and_Deredden_example.ipynb
+++ b/examples/core_examples/FluxtoMag_and_Deredden_example.ipynb
@@ -27,7 +27,7 @@
     "import tempfile\n",
     "from rail.core.stage import RailStage\n",
     "from rail.core.data import TableHandle\n",
-    "from rail.core.utils import RAILDIR\n",
+    "from rail.core.utils import find_rail_file\n",
     "from rail.tools.utilPhotometry import LSSTFluxToMagConverter, Dereddener"
    ]
   },
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
-    "example_file = os.path.join(RAILDIR, \"rail\", \"examples_data\", \"testdata\", \"rubin_dm_dc2_example.pq\")\n",
+    "example_file = find_rail_file(\"examples_data/testdata/rubin_dm_dc2_example.pq\")\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, example_file)"
    ]
   },
@@ -232,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/core_examples/Iterate_Tabular_Data.ipynb
+++ b/examples/core_examples/Iterate_Tabular_Data.ipynb
@@ -78,8 +78,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "pdfs_file = os.path.join(RAILDIR, \"rail/examples_data/testdata/test_dc2_training_9816.hdf5\")"
+    "from rail.core.utils import find_rail_file\n",
+    "pdfs_file = find_rail_file(\"examples_data/testdata/test_dc2_training_9816.hdf5\")"
    ]
   },
   {
@@ -193,6 +193,14 @@
     "for  xx in x:\n",
     "    print(xx[0], xx[1], xx[2]['id'][0])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05c1c19b-939c-4483-847a-69e88dd2e6c5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -211,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/core_examples/Useful_Utilities.ipynb
+++ b/examples/core_examples/Useful_Utilities.ipynb
@@ -570,7 +570,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "rail",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -588,5 +588,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/core_examples/hyperbolic_magnitude_test.ipynb
+++ b/examples/core_examples/hyperbolic_magnitude_test.ipynb
@@ -75,8 +75,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "testFile = os.path.join(RAILDIR, 'rail', 'examples_data', 'testdata', 'test_dc2_training_9816.pq')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.pq')\n",
     "test_mags = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]
   },
@@ -208,6 +208,14 @@
     "plt.ylabel(\"Classical $-$ hyperbolic magnitude\")\n",
     "plt.title(\"$r$-band magnitude\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49f8f5d4-6783-4c87-9560-4fad305ac237",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -229,7 +237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/creation_examples/degradation-demo.ipynb
+++ b/examples/creation_examples/degradation-demo.ipynb
@@ -498,6 +498,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/creation_examples/dsps_sed_demo.ipynb
+++ b/examples/creation_examples/dsps_sed_demo.ipynb
@@ -2,6 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "# Demo of SED and photometry calculations with DSPS\n",
     "\n",
@@ -12,22 +18,28 @@
     "This notebook demonstrates some basic usage of the DSPS library. In particular, for a galaxy with some arbitrary star formation history, we'll see how to calculate its restframe SED, and its absolute and apparent magnitude in some band.\n",
     "\n",
     "SPS calculations are based on a set of template SEDs of simple stellar populations (SSPs). Supplying such templates is outside the planned scope of the DSPS package, and so they will need to be retrieved from some other library. For example, the FSPS library supplies such templates in a convenient form."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "### SingleSedModeler"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "The SingleSedModeler class allows the user to generate a single rest-frame SED at the time with DSPS.\n",
     "\n",
@@ -38,14 +50,17 @@
     "- the star-formation history of galaxies in units of Msun/yr\n",
     "- galaxy metallicity at the time of observation in units of log10(Z)\n",
     "- log normal scatter of the galaxy metallicity at the time of observation\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -54,14 +69,17 @@
     "from rail.core.data import TableHandle\n",
     "import numpy as np\n",
     "import h5py"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
@@ -71,14 +89,17 @@
     "default_rail_fsps_files_folder = os.path.join(RAIL_DSPS_DIR, 'rail', 'examples_data', 'creation_data',\n",
     "                                              'data', 'dsps_default_data')\n",
     "input_file = os.path.join(default_rail_fsps_files_folder, 'input_galaxy_properties_dsps.hdf5')"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "n_galaxies = 100\n",
@@ -102,35 +123,44 @@
     "    h5table.create_dataset(name='star_formation_history', data=star_formation_history)\n",
     "    h5table.create_dataset(name='stellar_metallicity', data=stellar_metallicity)\n",
     "    h5table.create_dataset(name='stellar_metallicity_scatter', data=stellar_metallicity_scatter)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "trainFile = os.path.join(input_file)\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "The user is also required to provide the template SSPs with which rail_dsps generates its rest-frame SEDs. Leaving it blank or to a non-existing file will lead rail_dsps to generate the default templates from NERSC."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspssinglesedmodeler = rail.dsps.DSPSSingleSedModeler.make_stage(name='DSPSSingleSedModeler',\n",
@@ -141,54 +171,69 @@
     "                                                                 stellar_metallicity_key='stellar_metallicity',\n",
     "                                                                 stellar_metallicity_scatter_key='stellar_metallicity_scatter',\n",
     "                                                                 restframe_sed_key='restframe_seds', default_cosmology=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspssinglesedmodel = dspssinglesedmodeler.fit_model(input_data=training_data)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspssinglesedmodel.data"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "### PopulationSedModeler"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "The PopulationSedModeler class works in a similar way as the SingleSedModeler class, but allows the user to generate a population of rest-frame SEDs using the native parallelization capabilities of jax.\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -197,14 +242,17 @@
     "from rail.core.data import TableHandle\n",
     "import numpy as np\n",
     "import h5py"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
@@ -213,14 +261,17 @@
     "default_rail_fsps_files_folder = os.path.join(RAIL_DSPS_DIR, 'rail', 'examples_data', 'creation_data',\n",
     "                                              'data', 'dsps_default_data')\n",
     "input_file = os.path.join(default_rail_fsps_files_folder, 'input_galaxy_properties_dsps.hdf5')"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "n_galaxies = 100\n",
@@ -244,26 +295,32 @@
     "    h5table.create_dataset(name='star_formation_history', data=star_formation_history)\n",
     "    h5table.create_dataset(name='stellar_metallicity', data=stellar_metallicity)\n",
     "    h5table.create_dataset(name='stellar_metallicity_scatter', data=stellar_metallicity_scatter)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "trainFile = os.path.join(input_file)\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspspopulationsedmodeler = rail.dsps.DSPSPopulationSedModeler.make_stage(name='DSPSPopulationSedModeler',\n",
@@ -275,44 +332,56 @@
     "                                                                         stellar_metallicity_key='stellar_metallicity',\n",
     "                                                                         stellar_metallicity_scatter_key='stellar_metallicity_scatter',\n",
     "                                                                         restframe_sed_key='restframe_seds', default_cosmology=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspspopulationsedmodel = dspspopulationsedmodeler.fit_model(input_data=training_data)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspspopulationsedmodel.data"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "### DSPSPhotometryCreator"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "This class allows the user to generate model photometry by computing the absolute and apparent magnitudes of galaxies from their input rest-frame SEDs. Although DSPSPopulationSedModeler generates the rest-frame SEDs that are needed for this class, the user can supply whatever external SED provided that the units are in Lsun/Hz.\n",
     "\n",
@@ -326,54 +395,66 @@
     "- a boolean keyword to use (True) the default cosmology in DSPS.\n",
     "\n",
     "If the latter keyword is set to False, then the user has to manually provide the values of Om0, w0, wa and h in the .sample function."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
     "import rail.dsps\n",
     "from rail.core.stage import RailStage\n",
     "from rail.core.data import TableHandle"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "DS = RailStage.data_store\n",
     "DS.__class__.allow_overwrite = True\n",
     "\n",
     "input_file = 'model_DSPSPopulationSedModeler.hdf5'"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "trainFile = os.path.join(input_file)\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspsphotometrycreator = rail.dsps.DSPSPhotometryCreator.make_stage(name='DSPSPhotometryCreator',\n",
@@ -388,53 +469,56 @@
     "                                                         ssp_templates_file=os.path.join(RAIL_DSPS_DIR,\n",
     "                                                         'rail/examples_data/creation_data/data/dsps_default_data/ssp_data_fsps_v3.2_lgmet_age.h5'),\n",
     "                                                         default_cosmology=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspsphotometry = dspsphotometrycreator.sample(input_data=training_data)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dspsphotometry.data"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/examples/creation_examples/example_GridSelection_for_HSC.ipynb
+++ b/examples/creation_examples/example_GridSelection_for_HSC.ipynb
@@ -38,7 +38,7 @@
     "import pandas as pd\n",
     "#from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.core.utils import RAILDIR, find_rail_file\n",
+    "from rail.core.utils import find_rail_file\n",
     "%matplotlib inline "
    ]
   },
@@ -317,7 +317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/creation_examples/example_ObsConditions.ipynb
+++ b/examples/creation_examples/example_ObsConditions.ipynb
@@ -76,7 +76,7 @@
    "source": [
     "import rail\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.core.utils import RAILDIR\n",
+    "from rail.core.utils import find_rail_file\n",
     "DS = RailStage.data_store\n",
     "DS.__class__.allow_overwrite = True"
    ]
@@ -224,10 +224,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = hp.read_map(os.path.join(RAILDIR, \"rail/examples_data/creation_data/data/survey_conditions/DC2-mask-neg-nside-128.fits\"))\n",
-    "weight = hp.read_map(os.path.join(RAILDIR, \"rail/examples_data/creation_data/data/survey_conditions/DC2-dr6-galcounts-i20-i25.3-nside-128.fits\"))\n",
-    "Med_5sd_i = hp.read_map(os.path.join(RAILDIR, \"rail/examples_data/creation_data/data/survey_conditions/minion_1016_dc2_Median_fiveSigmaDepth_i_and_nightlt1825_HEAL.fits\"))"
+    "mask = hp.read_map(find_rail_file(\"examples_data/creation_data/data/survey_conditions/DC2-mask-neg-nside-128.fits\"))\n",
+    "weight = hp.read_map(find_rail_file(\"examples_data/creation_data/data/survey_conditions/DC2-dr6-galcounts-i20-i25.3-nside-128.fits\"))\n",
+    "Med_5sd_i = hp.read_map(find_rail_file(\"examples_data/creation_data/data/survey_conditions/minion_1016_dc2_Median_fiveSigmaDepth_i_and_nightlt1825_HEAL.fits\"))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75aa59ef-bfad-4159-9f89-a46390c70ea7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -292,7 +300,7 @@
    "outputs": [],
    "source": [
     "airmass_degrader = ObsCondition.make_stage(\n",
-    "    map_dict={\"airmass\": os.path.join(RAILDIR, \"rail/examples_data/creation_data/data/survey_conditions/minion_1016_dc2_Median_airmass_i_and_nightlt1825_HEAL.fits\"),\n",
+    "    map_dict={\"airmass\": find_rail_file(\"examples_data/creation_data/data/survey_conditions/minion_1016_dc2_Median_airmass_i_and_nightlt1825_HEAL.fits\"),\n",
     "             \"nYrObs\": 5.0}\n",
     ")"
    ]
@@ -342,7 +350,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Med_airmass_i = hp.read_map(os.path.join(RAILDIR, \"rail/examples_data/creation_data/data/survey_conditions/minion_1016_dc2_Median_airmass_i_and_nightlt1825_HEAL.fits\"))"
+    "Med_airmass_i = hp.read_map(find_rail_file(\"examples_data/creation_data/data/survey_conditions/minion_1016_dc2_Median_airmass_i_and_nightlt1825_HEAL.fits\"))"
    ]
   },
   {
@@ -405,6 +413,14 @@
    "source": [
     "In both cases, we see a negative correlation between the airmass and the SNR in $i$ and $r$ bands, as expected."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16ed8443-6979-4741-8108-da9738b93355",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -423,7 +439,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/creation_examples/example_SpecSelection_for_zCOSMOS.ipynb
+++ b/examples/creation_examples/example_SpecSelection_for_zCOSMOS.ipynb
@@ -42,8 +42,8 @@
     "import tables_io\n",
     "import pandas as pd\n",
     "#from rail.core.data import TableHandle\n",
+    "from rail.core.utils import find_rail_file\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.core.utils import RAILDIR\n",
     "%matplotlib inline "
    ]
   },
@@ -212,7 +212,7 @@
    "outputs": [],
    "source": [
     "# compare to sum of ratios * 100\n",
-    "ratio_file=os.path.join(RAILDIR, 'rail/examples_data/creation_data/data/success_rate_data/zCOSMOS_success.txt')"
+    "ratio_file=find_rail_file('examples_data/creation_data/data/success_rate_data/zCOSMOS_success.txt')"
    ]
   },
   {
@@ -291,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/estimation_examples/CMNN_Demo.ipynb
+++ b/examples/estimation_examples/CMNN_Demo.ipynb
@@ -135,9 +135,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]

--- a/examples/estimation_examples/Fzboost_PDF_Representation_Comparison.ipynb
+++ b/examples/estimation_examples/Fzboost_PDF_Representation_Comparison.ipynb
@@ -56,9 +56,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]
@@ -408,11 +408,18 @@
     "except FileNotFoundError:\n",
     "    pass"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "rail",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/examples/estimation_examples/GPz_estimation_example.ipynb
+++ b/examples/estimation_examples/GPz_estimation_example.ipynb
@@ -60,10 +60,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# RAILDIR is a convenience variable set within RAIL that stores the path to the package as installed on your machine.  We have several example data files that are copied with RAIL that we can use for our example run, let's grab those files, one for training/validation, and the other for testing:\n",
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "# find_rail_file is a convenience function that finds a file in the RAIL ecosystem   We have several example data files that are copied with RAIL that we can use for our example run, let's grab those files, one for training/validation, and the other for testing:\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]

--- a/examples/estimation_examples/NZDir.ipynb
+++ b/examples/estimation_examples/NZDir.ipynb
@@ -86,9 +86,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)"
    ]
   },
@@ -484,7 +484,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/estimation_examples/RAIL_estimation_demo.ipynb
+++ b/examples/estimation_examples/RAIL_estimation_demo.ipynb
@@ -171,9 +171,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]
@@ -518,6 +518,20 @@
    "source": [
     "The results look very good! FlexZBoost is a mature algorithm, and with representative training data we see a very tight correlation with true redshift and few outliers due to physical degeneracies.<br>"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -536,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/estimation_examples/nzdir_as_pipeline.ipynb
+++ b/examples/estimation_examples/nzdir_as_pipeline.ipynb
@@ -55,9 +55,9 @@
    "outputs": [],
    "source": [
     "# Load up the example healpix 9816 data and stick in the DataStore\n",
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]

--- a/examples/estimation_examples/somocluSOM_demo.ipynb
+++ b/examples/estimation_examples/somocluSOM_demo.ipynb
@@ -47,7 +47,7 @@
     "import tables_io\n",
     "from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.core.utils import RAILDIR\n"
+    "from rail.core.utils import find_rail_file\n"
    ]
   },
   {
@@ -342,7 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "testfile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testfile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
     "data = tables_io.read(testfile)['photometry']\n",
     "mask = ((data['redshift'] > 0.2) & (data['redshift']<0.5))\n",
     "brightmask = ((mask) & (data['mag_i_lsst']<23.5))\n",
@@ -365,7 +365,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "specfile = os.path.join(RAILDIR, \"rail/examples_data/testdata/test_dc2_validation_9816.hdf5\")\n",
+    "specfile = find_rail_file(\"examples_data/testdata/test_dc2_validation_9816.hdf5\")\n",
     "spec_data = tables_io.read(specfile)['photometry']\n",
     "smask = (spec_data['mag_i_lsst'] <23.5)\n",
     "trim_spec = {}\n",
@@ -767,7 +767,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/estimation_examples/somocluSOMcluster_demo.ipynb
+++ b/examples/estimation_examples/somocluSOMcluster_demo.ipynb
@@ -49,7 +49,7 @@
     "import tables_io\n",
     "from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.core.utils import RAILDIR\n",
+    "from rail.core.utils import find_rail_file\n",
     "from rail.estimation.algos.somoclu_som import SOMocluInformer, SOMocluSummarizer\n",
     "from rail.estimation.algos.somoclu_som import get_bmus, plot_som"
    ]
@@ -367,7 +367,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "testfile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testfile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
     "data = tables_io.read(testfile)['photometry']\n",
     "mask = ((data['redshift'] > 0.2) & (data['redshift']<0.5))\n",
     "brightmask = ((mask) & (data['mag_i_lsst']<23.5))\n",
@@ -390,7 +390,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "specfile = os.path.join(RAILDIR, \"rail/examples_data/testdata/test_dc2_validation_9816.hdf5\")\n",
+    "specfile = find_rail_file(\"examples_data/testdata/test_dc2_validation_9816.hdf5\")\n",
     "spec_data = tables_io.read(specfile)['photometry']\n",
     "smask = (spec_data['mag_i_lsst'] <23.5)\n",
     "trim_spec = {}\n",
@@ -887,7 +887,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/estimation_examples/test_sampled_summarizers.ipynb
+++ b/examples/estimation_examples/test_sampled_summarizers.ipynb
@@ -121,9 +121,9 @@
    "outputs": [],
    "source": [
     "# Load up the example healpix 9816 data and stick in the DataStore\n",
-    "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "from rail.core.utils import find_rail_file\n",
+    "trainFile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]
@@ -655,6 +655,14 @@
    "source": [
     "Again, not a huge spread in predicted mean redshifts based solely on bootstraps, even with only ~20,000 galaxies."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b206103c-31bd-4e7a-bacf-d35268d52dcb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -673,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/evaluation_examples/demo.ipynb
+++ b/examples/evaluation_examples/demo.ipynb
@@ -93,9 +93,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "pdfs_file = os.path.join(RAILDIR, 'rail/examples_data/evaluation_data/data/output_fzboost.hdf5')\n",
-    "ztrue_file = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')"
+    "from rail.core.utils import find_rail_file\n",
+    "pdfs_file = find_rail_file('examples_data/evaluation_data/data/output_fzboost.hdf5')\n",
+    "ztrue_file = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')"
    ]
   },
   {
@@ -552,6 +552,13 @@
    "source": [
     "We note that all of the quantities as run individually are identical to the quantities in our summary table - a nice check that things have run properly."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -570,7 +577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -132,9 +132,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.core.utils import RAILDIR\n",
-    "\n",
-    "flow_file = os.path.join(RAILDIR, \"examples/goldenspike/data/pretrained_flow.pkl\")\n",
     "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
     "band_dict = {band: f\"mag_{band}_lsst\" for band in bands}\n",
     "rename_dict = {f\"mag_{band}_lsst_err\": f\"mag_err_{band}_lsst\" for band in bands}\n"


### PR DESCRIPTION
The function find_rail_file will search the rail namespace for a file.  This is more robust than using RAILDIR, because it will work even if some of the packages are installed from source and some are pip-installed. 
