### PR TITLE
fix description of estimators in golden spike NB addresses #20

### DIFF
--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -504,7 +504,7 @@
     "\n",
     "`BPZliteEstimator` is a template-based photo-z code that outputs the posterior estimated given likelihoods calculated using a template set combined with a Bayesian prior. See Benitez (2000) for more details.<br>\n",
     "`KNearNeighEstimator` is a simple photo-z code that finds the K nearest neighbor training galaxies in color/magnitude space and creates a weighted (by distance) mixture model PDF based on the redshifts of those K neighbors.<br>\n",
-    "`FlexZBoostEstimator` is a mature photo-z algorithm that estimates a PDF for each galaxy using a conditional density estimate using the training data.<br>\n"
+    "`FlexZBoostEstimator` is a mature photo-z algorithm that estimates a PDF for each galaxy via a conditional density estimate using the training data.  See [Izbicki & Lee (2017)](https://doi.org/10.1214/17-EJS1302) for more details.<br>\n"
    ]
   },
   {

--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "author: Sam Schmidt, Eric Charles, Alex Malz, John Franklin Crenshaw, others...\n",
     "\n",
-    "last run successfully: April 28, 2023 (with qp-prob >= 0.8.2)"
+    "last run successfully: Oct 23, 2023"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "source": [
     "RAIL now uses ceci as a back-end, which takes care of a lot of file I/O decisions to be consistent with other choices in DESC.\n",
     "\n",
-    "This bit effectively overrides a ceci default to prevent overwriting previous results, generally good but not necessary for this demo.\n",
+    "The data_store commands in the cell below effectively override a ceci default to prevent overwriting previous results, generally good but not necessary for this demo.\n",
     "\n",
     "The `DataStore` uses `DataHandle` objects to keep track of the connections between the various stages.  When one stage returns a `DataHandle` and then you pass that `DataHandle` to another stage, the underlying code can establish the connections needed to build a reproducilble pipeline.   "
    ]
@@ -500,11 +500,11 @@
    "source": [
     "## Estimate photo-z posteriors\n",
     "\n",
-    "More details about the estimators is available in the `rail/examples/estimation_examples/RAIL_estimation_demo.ipynb` notebook.\n",
+    "More detail on the specific estimators used here is available in the `rail/examples/estimation_examples/RAIL_estimation_demo.ipynb` notebook, but here is a very brief summary of the three estimators used in this notebook:\n",
     "\n",
-    "`RandomGaussEstimator` is a very simple class that does not actually predict a meaningful photo-z, instead it produces a randomly drawn Gaussian for each galaxy.<br>\n",
-    "`trainZEstimator` is our \"pathological\" estimator, it makes a PDF from a histogram of the training data and assigns that PDF to every galaxy.<br>\n",
-    "`BPZliteEstimator` is a template-based code that outputs the posterior estimated given a specific template set and Bayesian prior. See Benitez (2000) for more details.<br>\n"
+    "`BPZliteEstimator` is a template-based photo-z code that outputs the posterior estimated given likelihoods calculated using a template set combined with a Bayesian prior. See Benitez (2000) for more details.<br>\n",
+    "`KNearNeighEstimator` is a simple photo-z code that finds the K nearest neighbor training galaxies in color/magnitude space and creates a weighted (by distance) mixture model PDF based on the redshifts of those K neighbors.<br>\n",
+    "`FlexZBoostEstimator` is a mature photo-z algorithm that estimates a PDF for each galaxy using a conditional density estimate using the training data.<br>\n"
    ]
   },
   {
@@ -830,7 +830,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Simple PR to fix which estimators are described to match those actually used in the golden spike.py notebook.  This addresses issue #20 
- [ x ] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->



## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
