### PR TITLE
Update smoke-test.yml to only alert on scheduled runs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         rail render-nb --skip examples/creation_examples/plotting_interface_skysim_cosmoDC2_COSMOS2020_demo.ipynb examples/${{ matrix.notebook-dir }}_examples/*.ipynb
     - name: Send status to Slack app (RAIL CI Reporter)
-      if: ${{ failure() }}
+      if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
       id: slack
       uses: slackapi/slack-github-action@v1.24.0
       with:


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Updating the smoke test's "alert slack" step to only trigger on scheduled runs

This lets us manually trigger smoke tests without cluttering the slack

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)