### PR TITLE
Fixed posterior nb for photerr 1.2

### DIFF
--- a/examples/creation_examples/posterior-demo.ipynb
+++ b/examples/creation_examples/posterior-demo.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "author: John Franklin Crenshaw, Sam Schmidt, Eric Charles, others...\n",
     "\n",
-    "last run successfully: August 2, 2023"
+    "last run successfully: March 7, 2024"
    ]
   },
   {
@@ -228,7 +228,7 @@
    "source": [
     "# set up the error model\n",
     "\n",
-    "n_samples = 30\n",
+    "n_samples = 50\n",
     "# create the FlowEngine\n",
     "flowEngine_degr = FlowCreator.make_stage(\n",
     "    name=\"degraded\", flow_file=flow_file, n_samples=n_samples\n",
@@ -444,7 +444,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Based on this histogram, I will marginalize over u band values from 27 to 31. Like how I tested different numbers of error samples above, here I will test different resolutions for the u band grid.\n",
+    "Based on this histogram, I will marginalize over u band values from 25 to 31. Like how I tested different numbers of error samples above, here I will test different resolutions for the u band grid.\n",
     "\n",
     "I will provide our new u band grid in the `marg_rules` dictionary, which will also include `\"flag\"` which tells `FlowEngine` what my flag for non-detections is.\n",
     "In this simple example, we are using a fixed grid for the u band, but notice that the u band rule takes the form of a function - this is because the grid over which to marginalize can be a function of any of the other variables in the row. \n",
@@ -476,7 +476,7 @@
     "    # set up the marginalization rules for this grid resolution\n",
     "    marg_rules = {\n",
     "        \"flag\": errorModel.config[\"ndFlag\"],\n",
-    "        \"u\": lambda row: np.linspace(27, 31, nbins),\n",
+    "        \"u\": lambda row: np.linspace(25, 31, nbins),\n",
     "    }\n",
     "\n",
     "    # calculate the posterior by marginalizing over u and sampling\n",
@@ -530,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {
@@ -539,5 +539,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Updating to PhotErr>=1.2 means that the photometric errors are greater, and therefore fewer galaxies passed the magnitude cut in the posterior notebook. This caused an indexing error in one of the plotting functions which assumes a minimum number of detected galaxies. This has been fixed so that there are now sufficient galaxies in the sample for the plot.


## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
