### PR TITLE
Adding `os` dependency to fix CI failure.

### DIFF
--- a/examples/core_examples/Useful_Utilities.ipynb
+++ b/examples/core_examples/Useful_Utilities.ipynb
@@ -227,6 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "from rail.core.utils import RAILDIR\n",
     "\n",
     "flow_file = os.path.join(\n",


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
This fixes the CI failure from issue #126 
