### PR TITLE
Update example notebook to use OldEvaluator

### DIFF
--- a/examples/evaluation_examples/Evaluation_Demo.ipynb
+++ b/examples/evaluation_examples/Evaluation_Demo.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "import rail\n",
     "from rail.evaluation.metrics.cdeloss import *\n",
-    "from rail.evaluation.evaluator import Evaluator\n",
+    "from rail.evaluation.evaluator import OldEvaluator\n",
     "from rail.core.data import QPHandle, TableHandle\n",
     "from rail.core.stage import RailStage\n",
     "from utils import plot_pit_qq, ks_plot\n",
@@ -174,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FZB_eval = Evaluator.make_stage(name='FZB_eval', truth=truth)"
+    "FZB_eval = OldEvaluator.make_stage(name='FZB_eval', truth=truth)"
    ]
   },
   {


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
