### PR TITLE
Fix GoldenSpike notebook with new base classes, collect new notebooks

### DIFF
--- a/examples/creation_examples/photerr_demo.ipynb
+++ b/examples/creation_examples/photerr_demo.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2610a0f0-0c71-4401-896f-734442bcd66d",
+   "metadata": {},
+   "source": [
+    "## Photometric error stage demo\n",
+    "\n",
+    "author: Tianqing Zhang, John-Franklin Crenshaw\n",
+    "\n",
+    "This notebook demonstrate the use of `rail.creation.degradation.photometric_errors`, which adds column for the  photometric noise to the catalog based on the package PhotErr developed by John-Franklin Crenshaw. The RAIL stage PhotoErrorModel inherit from the Noisifier base classes, and the LSST, Roman, Euclid child classes inherit from the PhotoErrorModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7a6adc3-68e8-4a1d-842f-bfb0960a1c4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from rail.creation.degradation.photometric_errors import LSSTErrorModel\n",
+    "from rail.creation.degradation.photometric_errors import RomanErrorModel\n",
+    "from rail.creation.degradation.photometric_errors import EuclidErrorModel\n",
+    "\n",
+    "from rail.core.data import PqHandle\n",
+    "from rail.core.stage import RailStage\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6912a740-31ea-4987-b06d-81ff17cd895a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a282c2ed-141b-4507-8254-dc8fbc9864dc",
+   "metadata": {},
+   "source": [
+    "### Create a random catalog with ugrizy+YJHF bands as the the true input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1078bc2a-fc54-41c3-bd30-6c447bb971d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.random.normal(23, 3, size = (1000,10))\n",
+    "\n",
+    "data_df = pd.DataFrame(data=data,    # values\n",
+    "            columns=['u', 'g', 'r', 'i', 'z', 'y', 'Y', 'J', 'H', 'F'])\n",
+    "data_truth = PqHandle('input')\n",
+    "data_truth.set_data(data_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a11f3db8-9b2d-405c-a1c5-832a6ffec0d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1da27deb-d167-4f38-8c59-f270184d6ab3",
+   "metadata": {},
+   "source": [
+    "### The LSST error model adds noise to the optical bands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f4862a-0621-46d4-8901-7e84b461c424",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_lsst = LSSTErrorModel.make_stage(name=\"error_model\")\n",
+    "\n",
+    "samples_w_errs = errorModel_lsst(data_truth)\n",
+    "samples_w_errs()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6282c42e-1a6f-480a-aa2b-817bd30d372f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 4), dpi=100)\n",
+    "\n",
+    "for band in \"ugrizy\":\n",
+    "    # pull out the magnitudes and errors\n",
+    "    mags = samples_w_errs.data[band].to_numpy()\n",
+    "    errs = samples_w_errs.data[band + \"_err\"].to_numpy()\n",
+    "\n",
+    "    # sort them by magnitude\n",
+    "    mags, errs = mags[mags.argsort()], errs[mags.argsort()]\n",
+    "\n",
+    "    # plot errs vs mags\n",
+    "    ax.plot(mags, errs, label=band)\n",
+    "\n",
+    "ax.legend()\n",
+    "ax.set(xlabel=\"Magnitude (AB)\", ylabel=\"Error (mags)\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50927ccb-4492-4bdd-a29b-0907704b2c59",
+   "metadata": {},
+   "source": [
+    "### The Roman error model adds noise to the infrared bands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d484a34b-cf10-45bd-8571-b78dc1818180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_Roman = RomanErrorModel.make_stage(name=\"error_model\", )\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25dcd9de-8612-4a98-a05b-07a1c9a66e36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_Roman.config['m5']['Y'] = 27.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ab2ef86-01a0-426a-a8ad-08d4e4079421",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_Roman.config['theta']['Y'] = 27.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c199c365-6d09-45ca-a1ea-bcf8c709c559",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples_w_errs_roman = errorModel_Roman(data_truth)\n",
+    "samples_w_errs_roman()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a12362dc-0689-43f3-b990-edff734010bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 4), dpi=100)\n",
+    "\n",
+    "for band in \"YJHF\":\n",
+    "    # pull out the magnitudes and errors\n",
+    "    mags = samples_w_errs_roman.data[band].to_numpy()\n",
+    "    errs = samples_w_errs_roman.data[band + \"_err\"].to_numpy()\n",
+    "\n",
+    "    # sort them by magnitude\n",
+    "    mags, errs = mags[mags.argsort()], errs[mags.argsort()]\n",
+    "\n",
+    "    # plot errs vs mags\n",
+    "    ax.plot(mags, errs, label=band)\n",
+    "\n",
+    "ax.legend()\n",
+    "ax.set(xlabel=\"Magnitude (AB)\", ylabel=\"Error (mags)\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "359de4ad-a47c-4dc5-8c81-53aeb92bdf42",
+   "metadata": {},
+   "source": [
+    "### The Euclid error model adds noise to YJH bands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "775d0a23-7435-4b01-83db-2234c3d24f57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_Euclid = EuclidErrorModel.make_stage(name=\"error_model\")\n",
+    "\n",
+    "samples_w_errs_Euclid = errorModel_Euclid(data_truth)\n",
+    "samples_w_errs_Euclid()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fcfe07a-5571-4dd3-8ad0-358964c1d493",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 4), dpi=100)\n",
+    "\n",
+    "for band in \"YJH\":\n",
+    "    # pull out the magnitudes and errors\n",
+    "    mags = samples_w_errs_Euclid.data[band].to_numpy()\n",
+    "    errs = samples_w_errs_Euclid.data[band + \"_err\"].to_numpy()\n",
+    "\n",
+    "    # sort them by magnitude\n",
+    "    mags, errs = mags[mags.argsort()], errs[mags.argsort()]\n",
+    "\n",
+    "    # plot errs vs mags\n",
+    "    ax.plot(mags, errs, label=band)\n",
+    "\n",
+    "ax.legend()\n",
+    "ax.set(xlabel=\"Magnitude (AB)\", ylabel=\"Error (mags)\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "268b3d37-b7fd-4ac1-8457-2104a87c9e6d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rail_env",
+   "language": "python",
+   "name": "rail_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -60,6 +60,7 @@
     "import os\n",
     "import numpy as np\n",
     "from pathlib import Path\n",
+    "from collections import OrderedDict\n",
     "from pzflow.examples import get_galaxy_data\n",
     "import tables_io\n"
    ]
@@ -91,7 +92,8 @@
     "from rail.estimation.algos.naive_stack import NaiveStackSummarizer\n",
     "from rail.estimation.algos.point_est_hist import PointEstHistSummarizer\n",
     "\n",
-    "from rail.evaluation.evaluator import OldEvaluator\n"
+    "from rail.evaluation.dist_to_point_evaluator import DistToPointEvaluator\n",
+    "\n"
    ]
   },
   {
@@ -283,6 +285,7 @@
     "    true_wavelen=5007.0,\n",
     "    wrong_wavelen=3727.0,\n",
     "    frac_wrong=0.05,\n",
+    "    seed = 1337\n",
     ")\n",
     "\n",
     "quantity_cut = QuantityCut.make_stage(\n",
@@ -411,6 +414,29 @@
     "test_data_pq = col_remapper_test(test_data_errs)\n",
     "test_data = table_conv_test(test_data_pq)\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb3b5698-6f44-4f93-a2a4-f817a68026b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data_handle = TableHandle('input')\n",
+    "od = OrderedDict()\n",
+    "od['photometry'] = test_data_orig.data.to_records()\n",
+    "test_data_handle.set_data(od)\n",
+    "test_data_handle.path  = './test_data_orig.hdf5'\n",
+    "test_data_handle.write()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58e17656-a898-42b9-a809-7a6f32638990",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -559,17 +585,50 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4f4b8b5a-3f5d-4192-b258-e35a2f0e5d4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ztrue_file = './test_data_orig.hdf5'\n",
+    "ztrue_data = DS.read_file('ztrue_data', TableHandle, ztrue_file)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "portuguese-graduate",
    "metadata": {},
    "outputs": [],
    "source": [
     "eval_dict = dict(bpz=bpz_estimated, fzboost=fzboost_estimated, knn=knn_estimated)\n",
-    "truth = test_data_orig\n",
+    "\n",
+    "evaluator_stage_dict = dict(\n",
+    "    metrics=['cdeloss', 'pit', 'brier'],\n",
+    "    _random_state=None,\n",
+    "    metric_config={\n",
+    "        'brier': {'limits':(0,3.1)},\n",
+    "        'pit':{'tdigest_compression': 1000},\n",
+    "    }\n",
+    ")\n",
+    "truth = ztrue_data\n",
     "\n",
     "result_dict = {}\n",
     "for key, val in eval_dict.items():\n",
-    "    the_eval = OldEvaluator.make_stage(name=f\"{key}_eval\", truth=truth)\n",
-    "    result_dict[key] = the_eval.evaluate(val, truth)\n"
+    "    the_eval = DistToPointEvaluator.make_stage(name='dist_to_point', force_exact=True, **evaluator_stage_dict)\n",
+    "    result_dict[key] = the_eval.evaluate(val, truth)\n",
+    "    \n",
+    "    \n",
+    "    \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "093c617a-b862-47c3-ad38-20de5d44cfb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_dict"
    ]
   },
   {
@@ -589,7 +648,7 @@
    "outputs": [],
    "source": [
     "results_tables = {\n",
-    "    key: tables_io.convertObj(val.data, tables_io.types.PD_DATAFRAME)\n",
+    "    key: tables_io.convertObj(val['summary'].data, tables_io.types.PD_DATAFRAME)\n",
     "    for key, val in result_dict.items()\n",
     "}\n"
    ]
@@ -794,7 +853,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "racial-stocks",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# TODO fix and add clean up scripts\n"
@@ -803,9 +864,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "rail_env",
    "language": "python",
-   "name": "python3"
+   "name": "rail_env"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Fix GoldenSpike notebook with new base classes, collect new notebooks

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
