### PR TITLE
make Evaluator stage names unique

### DIFF
--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -614,7 +614,7 @@
     "\n",
     "result_dict = {}\n",
     "for key, val in eval_dict.items():\n",
-    "    the_eval = DistToPointEvaluator.make_stage(name='dist_to_point', force_exact=True, **evaluator_stage_dict)\n",
+    "    the_eval = DistToPointEvaluator.make_stage(name=f'{key}_dist_to_point', force_exact=True, **evaluator_stage_dict)\n",
     "    result_dict[key] = the_eval.evaluate(val, truth)\n",
     "    \n",
     "    \n",
@@ -866,7 +866,7 @@
   "kernelspec": {
    "display_name": "rail_env",
    "language": "python",
-   "name": "rail_env"
+   "name": "python"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

#135 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
