### PR TITLE
change kernel of the notebook back to vanilla python 3

### DIFF
--- a/examples/creation_examples/photerr_demo.ipynb
+++ b/examples/creation_examples/photerr_demo.ipynb
@@ -255,9 +255,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "rail_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "rail_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/creation_examples/plotting_interface_skysim_cosmoDC2_COSMOS2020_demo.ipynb
+++ b/examples/creation_examples/plotting_interface_skysim_cosmoDC2_COSMOS2020_demo.ipynb
@@ -1551,9 +1551,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "new_rail_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "new_rail_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -864,9 +864,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "rail_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
