### PR TITLE
Fixing smoke test failures

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -32,6 +32,9 @@ jobs:
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: (Temporarily) roll back ceci to pre-v2
+      run: |
+        pip install ceci==1.17
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests

--- a/examples/core_examples/Useful_Utilities.ipynb
+++ b/examples/core_examples/Useful_Utilities.ipynb
@@ -75,7 +75,7 @@
    "source": [
     "import rail\n",
     "import rail.stages\n",
-    "rail.stages.import_and_attach_all()\n"
+    "rail.stages.import_and_attach_all()"
    ]
   },
   {
@@ -136,9 +136,7 @@
    "source": [
     "### Listing imported stages (2/2)\n",
     "\n",
-    "Now, let's try listing imported stages again.\n",
-    "\n",
-    "Note that we can now just call `stage.RailStage` instead of `rail.core.stage.RailStage`."
+    "Now, let's try listing imported stages again, and notice how many more we get."
    ]
   },
   {
@@ -147,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for val in stage.RailStage.pipeline_stages.values():\n",
+    "for val in rail.core.stage.RailStage.pipeline_stages.values():\n",
     "    print(val[0])"
    ]
   },
@@ -166,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for val in stage.RailStage.pipeline_stages.values():\n",
+    "for val in rail.core.stage.RailStage.pipeline_stages.values():\n",
     "    if issubclass(val[0], rail.estimation.estimator.CatEstimator):\n",
     "        print(val[0])"
    ]
@@ -188,7 +186,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DS = stage.RailStage.data_store\n",
+    "DS = rail.core.stage.RailStage.data_store\n",
     "DS.__class__.allow_overwrite = True"
    ]
   },
@@ -278,11 +276,12 @@
    "outputs": [],
    "source": [
     "# Now, we have to set up some other variables for our pipeline:\n",
+    "import numpy as np\n",
     "\n",
     "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
     "band_dict = {band: f\"mag_{band}_lsst\" for band in bands}\n",
     "rename_dict = {f\"mag_{band}_lsst_err\": f\"mag_err_{band}_lsst\" for band in bands}\n",
-    "post_grid = [float(x) for x in np.linspace(0.0, 5, 21)]\n"
+    "post_grid = [float(x) for x in np.linspace(0.0, 5, 21)]"
    ]
   },
   {
@@ -585,7 +584,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/examples/core_examples/Useful_Utilities.ipynb
+++ b/examples/core_examples/Useful_Utilities.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "import rail.stages\n",
-    "for val in rail.core.RailStage.pipeline_stages.values():\n",
+    "for val in rail.core.stage.RailStage.pipeline_stages.values():\n",
     "    print(val[0])"
    ]
   },
@@ -138,7 +138,7 @@
     "\n",
     "Now, let's try listing imported stages again.\n",
     "\n",
-    "Note that we can now just call `RailStage` instead of `rail.core.RailStage`."
+    "Note that we can now just call `RailStage` instead of `rail.core.stage.RailStage`."
    ]
   },
   {

--- a/examples/core_examples/Useful_Utilities.ipynb
+++ b/examples/core_examples/Useful_Utilities.ipynb
@@ -138,7 +138,7 @@
     "\n",
     "Now, let's try listing imported stages again.\n",
     "\n",
-    "Note that we can now just call `RailStage` instead of `rail.core.stage.RailStage`."
+    "Note that we can now just call `stage.RailStage` instead of `rail.core.stage.RailStage`."
    ]
   },
   {
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for val in RailStage.pipeline_stages.values():\n",
+    "for val in stage.RailStage.pipeline_stages.values():\n",
     "    print(val[0])"
    ]
   },
@@ -166,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for val in RailStage.pipeline_stages.values():\n",
+    "for val in stage.RailStage.pipeline_stages.values():\n",
     "    if issubclass(val[0], rail.estimation.estimator.CatEstimator):\n",
     "        print(val[0])"
    ]
@@ -188,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DS = RailStage.data_store\n",
+    "DS = stage.RailStage.data_store\n",
     "DS.__class__.allow_overwrite = True"
    ]
   },


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Should fix the rail smoke test failures (when all the following conditions are completed)

### Context: 
The canary in the mine was Useful_Utilities, which was failing with `NameError: name 'RailStage' is not defined` at [this point in this run](https://github.com/LSSTDESC/rail/actions/runs/9834845316/job/27147354240#:~:text=NameError%3A%20name%20%27RailStage%27%20is%20not%20defined).

### Main change: RailStage import
- RailStage is now accessed via `rail.core.stage.RailStage` (previously `rail.core.RailStage`)
- We don't seem to get RailStage when we run `import_and_attach_all` anymore
- There could be some way to still get this, but for the time being, I think it should be fine to access RailStage via `rail.core.stage.RailStage` or import it as from `rail.core.stage import RailStage` or such

### Also: ceci pre-v2 rollback
- I've temporarily added a step to the smoke_test workflow to roll back ceci to be pre-v2, as that introduced a new error to the mix today (and Joe has said we shouldn't be using ceci v2 yet)
- I don't mind a different strategy for this, but figured pinning a pre-v2 version in the dependencies would require us to roll out a new release, which would get in the way of things. I'm making/self-assigning #151 on my radar.

### Finally: PZFlow import
- I believe (/am hoping) the remaining error will be fixed with this pzflow update I have in this other PR:
- LSSTDESC/rail_pzflow#14
