### PR TITLE
Update for ceci version 2

### DIFF
--- a/docs/source/new_rail_stage.rst
+++ b/docs/source/new_rail_stage.rst
@@ -35,8 +35,6 @@ The following example has all of the required pieces of a ``RailStage`` and almo
    inputs = [('input', PqHandle)]
        outputs = [('output', PqHandle)]
 
-       def __init__(self, args, comm=None):
-           RailStage.__init__(self, args, comm=comm)
 
        def run(self):
            data = self.get_data('input', allow_missing=True)
@@ -101,8 +99,8 @@ Here is an example of a slightly more complicated ``RailStage``.
        outputs = [('output', QPHandle),
                   ('single_NZ', QPHandle)]
 
-       def __init__(self, args, comm=None):
-           PZSummarizer.__init__(self, args, comm=comm)
+       def __init__(self, args, **kwargs):
+           super().__init__(self, args, **kwargs)
            self.zgrid = None
 
        def run(self):


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.
    