### PR TITLE
Update BPZ example notebook to include new filter_list param #158

### DIFF
--- a/examples/estimation_examples/BPZ_lite_demo.ipynb
+++ b/examples/estimation_examples/BPZ_lite_demo.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Authors:** Sam Schmidt\n",
     "\n",
-    "**Last Successfully Run:** Nov 14, 2023"
+    "**Last Successfully Run:** Sep 20, 2024"
    ]
   },
   {
@@ -81,16 +81,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fbaac331-aa5a-4a90-8b85-16929cffc751",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "RAILDIR"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "979d5363-af4e-4478-9820-29214292bf16",
    "metadata": {},
@@ -102,7 +92,49 @@
     "\n",
     "`bpz-1.99.3`, the code written by Dan Coe and Narcisso Benitez and available at https://www.stsci.edu/~dcoe/BPZ/, uses a default set of eight SED templates: four templates from Coleman, Wu, & Weedman (CWW, one Elliptical, two Spirals Sbc and Scd, and one Irregular), two starburst (WB) templates, and two very blue star forming templates generated using Bruzual & Charlot models with very young ages of 25Myr and 5Myr.  The original BPZ paper, Benitez(2000) computed a \"default\" prior fit to data from the Hubble Deep Field North (HDFN).  A pickle file with these parameters and the default SEDs are included with RAIL, named `CWW_HDFN_prior.pkl`.  You can run BPZliteEstimator with these default templates and priors without doing any training, the equivalent of \"running BPZ with the defaults\" had you downloaded bpz-1.99.3 and run it.  **Note, however**, that the cosmoDC2_v1.1.4 dataset has a population of galaxy SEDs that are fairly different from the \"default\" CWWSB templates, and the prior distributions do not exactly match.  So, you will get results that do not look particularly good.  We will demonstrate that use case here, though, as it is the most simple way to run the code out of the box (and illustrates the dangers of grabbing code and running it out of the box):\n",
     "\n",
-    "We need to set up a RAIL stage for the default run of BPZ, including specifying the location of the model pickle file:"
+    "We need to set up a RAIL stage for the default run of BPZ, including specifying the location of the model pickle file, which is located included in the `rail_base` package and can be found relative to `RAILDIR` at `rail/examples_data/estimation_data/data/CWW_HDFN_prior.pkl`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e9a8c4d-62d4-41c0-b007-fdc73c81cc4b",
+   "metadata": {},
+   "source": [
+    "`rail_bpz` attempts to set \"sensible\" defaults for an expected run on Rubin data, including for the magnitude and magnitude error column names.  While the defaults match the names in our small example datasets, we will set the configuration parameters explicitly so that users can see how this is done.  The names of the magnitudes are read in as a list by the configuration parameter `bands`, while the magnitude errors the parameter `err_bands`.\n",
+    "\n",
+    "`BPZ` works by creating synthetic expected magnitudes by convolving the SEDs with filter curves, so `rail_bpz` needs to know which filter files to use.  The names of the filters are specified by the `filter_list` configuration parameter, and should consist of a list of strings containing the names of the files, minus the \".sed\" suffix.  Also note that these files must be located in the `SED` directory where `BPZ` expects to find all filters.  This is defined, relative to `RAILDIR` as:\n",
+    "```RAILDIR + '/rail/examples_data/estimation_data/data/FILTER'```\n",
+    "\n",
+    "Also note that the `bands`, `err_bands`, and `filter_list` lists are required to be of the same length, and must be in the same order, usually ascending in wavelength, i.e. all three would be ordered u,g,r,i,z,y for Rubin data.\n",
+    "\n",
+    "Let's make lists containing the expected bands, errors, and filter names.  Our file contains magnitudes with names of the form \"mag_{band}_lsst\" and magnitude errors named like \"mag_err_{band}_lsst\".  This example data is from the DESC DC2 simulations, and our default filter bandpass curves haves names of the form \"DC2LSST_{band}.sed\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e57f155b-55ac-48a0-acff-2ebb2bdfceb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
+    "lsst_bands = []\n",
+    "lsst_errs = []\n",
+    "lsst_filts = []\n",
+    "for band in bands:\n",
+    "    lsst_bands.append(f\"mag_{band}_lsst\")\n",
+    "    lsst_errs.append(f\"mag_err_{band}_lsst\")\n",
+    "    lsst_filts.append(f\"DC2LSST_{band}\")\n",
+    "print(lsst_bands)\n",
+    "print(lsst_filts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9b5ca91-35e4-4895-8072-a620e57f7a10",
+   "metadata": {},
+   "source": [
+    "Now, let's set up a dictionary of configuration parameters and set up to run the estimator."
    ]
   },
   {
@@ -114,6 +146,7 @@
    "source": [
     "hdfnfile = os.path.join(RAILDIR, \"rail/examples_data/estimation_data/data/CWW_HDFN_prior.pkl\")\n",
     "default_dict = dict(hdf5_groupname=\"photometry\", output=\"bpz_results_defaultprior.hdf5\",\n",
+    "                    bands=lsst_bands, err_bands=lsst_errs, filter_list=lsst_filts,\n",
     "                    prior_band=\"mag_i_lsst\", no_prior=False)\n",
     "run_default = BPZliteEstimator.make_stage(name=\"bpz_def_prior\", model=hdfnfile, **default_dict)"
    ]
@@ -715,7 +748,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Quick update to the BPZ demo notebook to mention and use the new filter_list param now that .columns file use has moved to the new param.  Very simple change, demo runs fine for me.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
