### PR TITLE
specify ref_band and redshift_col after updates in unrec_blending

### DIFF
--- a/examples/creation_examples/blending_degrader_demo.ipynb
+++ b/examples/creation_examples/blending_degrader_demo.ipynb
@@ -54,12 +54,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = np.random.normal(23, 3, size = (1000,12))\n",
+    "data = np.random.normal(24, 3, size = (1000,13))\n",
     "data[:, 0] = np.random.uniform(low=0, high=0.03, size=1000)\n",
     "data[:, 1] = np.random.uniform(low=0, high=0.03, size=1000)\n",
+    "data[:, 2] = np.random.uniform(low=0, high=2, size=1000)\n",
     "\n",
     "data_df = pd.DataFrame(data=data,    # values\n",
-    "            columns=['ra', 'dec', 'u', 'g', 'r', 'i', 'z', 'y', 'Y', 'J', 'H', 'F'])\n",
+    "            columns=['ra', 'dec', 'z_true', 'u', 'g', 'r', 'i', 'z', 'y', 'Y', 'J', 'H', 'F'])\n",
     "\n",
     "data_truth_handle = DS.add_data('input', data_df, PqHandle)\n",
     "data_truth = data_truth_handle.data"
@@ -106,7 +107,7 @@
     "## model configuration; linking length is in arcsecs\n",
     "\n",
     "blModel = UnrecBlModel.make_stage(name='unrec_bl_model', ra_label='ra', dec_label='dec', linking_lengths=1.0, \\\n",
-    "                                  bands='ugrizy', ref_band = 'i', redshift_col = 'z')\n",
+    "                                  bands='ugrizy', ref_band = 'i', redshift_col = 'z_true')\n",
     "blModel.get_config_dict()\n"
    ]
   },
@@ -151,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "b = 'r'\n",
+    "b = 'i'\n",
     "plt.hist(data_truth[b], bins=np.linspace(10, 30, 20), label='Original')\n",
     "plt.hist(samples_w_bl[b], bins=np.linspace(10, 30, 20),  fill=False, label='w. Unrec-BL')\n",
     "\n",
@@ -163,18 +164,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1d51c15-1e04-4b22-9abb-9b267965dbeb",
+   "id": "51d759a6-2d27-42d6-896e-098059a25ffe",
    "metadata": {},
    "outputs": [],
    "source": [
-    "flux = 10**(-(data_truth[b]-28.10)/2.5)       # r band zp for lsst is 28.10\n",
-    "flux_bl = 10**(-(samples_w_bl[b]-28.10)/2.5)\n",
     "\n",
-    "plt.hist(flux, bins=np.linspace(0, 10000, 40), label='Original')\n",
-    "plt.hist(flux_bl, bins=np.linspace(0, 10000, 40), fill=False, label='w. Unrec-BL')\n",
+    "plt.hist(data_truth['z_true'], bins=20, label='True Redshift')\n",
+    "plt.hist(samples_w_bl['z_weighted'], bins=20,  fill=False, label='Weighted Mean')\n",
     "\n",
-    "plt.xlabel(fr'Flux ${b}$', fontsize=14)\n",
-    "plt.yscale('log')\n",
+    "plt.xlabel(fr'Rdshift', fontsize=14)\n",
     "plt.legend(fontsize=12)\n",
     "plt.show()\n"
    ]
@@ -202,8 +200,9 @@
     "    rand_ind = np.random.randint(len(samples_w_bl))\n",
     "    this_bl = samples_w_bl.iloc[rand_ind]\n",
     "    group_id = this_bl['group_id']\n",
-    "    \n",
-    "    FoF_group = component_ind.query(f\"group_id == {group_id}\")\n",
+    "\n",
+    "    mask = (component_ind['group_id'] == group_id)\n",
+    "    FoF_group = component_ind[mask]\n",
     "    group_size = len(FoF_group)\n",
     "\n",
     "truth_comp = data_truth.iloc[FoF_group.index]\n",
@@ -275,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/examples/creation_examples/blending_degrader_demo.ipynb
+++ b/examples/creation_examples/blending_degrader_demo.ipynb
@@ -106,7 +106,7 @@
     "## model configuration; linking length is in arcsecs\n",
     "\n",
     "blModel = UnrecBlModel.make_stage(name='unrec_bl_model', ra_label='ra', dec_label='dec', linking_lengths=1.0, \\\n",
-    "                                  bands='ugrizy')\n",
+    "                                  bands='ugrizy', ref_band = 'i', redshift_col = 'z')\n",
     "blModel.get_config_dict()\n"
    ]
   },
@@ -275,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/creation_examples/blending_degrader_demo.ipynb
+++ b/examples/creation_examples/blending_degrader_demo.ipynb
@@ -106,8 +106,10 @@
    "source": [
     "## model configuration; linking length is in arcsecs\n",
     "\n",
+    "lsst_zp_dict = {'u':12.65, 'g':14.69, 'r':14.56, 'i': 14.38, 'z':13.99, 'y': 13.02}\n",
     "blModel = UnrecBlModel.make_stage(name='unrec_bl_model', ra_label='ra', dec_label='dec', linking_lengths=1.0, \\\n",
-    "                                  bands='ugrizy', ref_band = 'i', redshift_col = 'z_true')\n",
+    "                                  bands='ugrizy', zp_dict=lsst_zp_dict, \n",
+    "                                  ref_band = 'i', redshift_col = 'z_true')\n",
     "blModel.get_config_dict()\n"
    ]
   },


### PR DESCRIPTION
The smoke test failed - 

This PR fixes the notebook after the underlying class was changed yesterday. 


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
