### PR TITLE
remove rail-sompz from rail_packages.yml

### DIFF
--- a/rail_packages.yml
+++ b/rail_packages.yml
@@ -12,7 +12,6 @@ rail_lephare: pz-rail-lephare
 rail_pzflow: pz-rail-pzflow
 rail_sklearn: pz-rail-sklearn
 rail_som: pz-rail-som
-rail_sompz: pz-rail-sompz
 rail_tpz: pz-rail-tpz
 rail_pipelines: pz-rail-pipelines
 rail_yaw: pz-rail-yaw


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Addresses #179 
`rail-sompz' is not yet included in rail v1.1.x. Removed from the sub-package installation list.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
