### PR TITLE
update somoclu notebooks so that the configuration parameters get the correct names

### DIFF
--- a/examples/estimation_examples/11_SomocluSOM.ipynb
+++ b/examples/estimation_examples/11_SomocluSOM.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bd28f643",
    "metadata": {},
    "outputs": [],
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "b50ddf15",
    "metadata": {},
    "outputs": [],
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f9429565",
    "metadata": {},
    "outputs": [],
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "90e006d2",
    "metadata": {},
    "outputs": [],
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "a27535d9",
    "metadata": {},
    "outputs": [],
@@ -133,8 +133,11 @@
     "- `model` (str): the name for the model file containing the SOM and associated parameters that will be written by this stage\n",
     "- `hdf5_groupname` (str): name of the hdf5 group (if any) where the photometric data resides in the training file\n",
     "- `n_rows` (int): the number of dimensions in the y-direction for our 2D SOM\n",
-    "- `m_columns` (int): the number of dimensions in the x-direction for our 2D SOM\n",
-    "- `som_iterations` (int): the number of iteration steps during SOM training.  SOMs can take a while to converge, so we will use a fairly large number of 500,000 iterations.\n",
+    "- `n_columns` (int): the number of dimensions in the x-direction for our 2D SOM\n",
+    "- `gridtype` (str): the parameter that specifies the grid form of the nodes. Options: `rectangular`(default) and `hexagonal`.\n",
+    "- `initialization` (str): the parameter specifying the method of initializing the SOM. Options: `pca`: principal componant analysis (default); `random`: randomly initialize the SOM.\n",
+    "- `maptype` (str): the parameter specifying the map topology. Options: `planar`(default) and `toroid`.\n",
+    "- `n_epochs` (int): the number of iteration steps during SOM training.  SOMs can take a while to converge, so we will use a fairly large number of 500,000 iterations.\n",
     "- `std_coeff` (float): the \"radius\" of how far to spread changes in the SOM \n",
     "- `som_learning_rate` (float): a number between 0 and 1 that controls how quickly the weighting function decreases.  SOM's are not guaranteed to converge mathematically, and so this parameter tunes how the response drops per iteration.  A typical values we might use might be between 0.5 and 0.75.\n",
     "- `column_usage` (str):  this value determines what values will be used to construct the SOM, valid choices are `colors`, `magandcolors`, and `columns`.  If set to `colors`, the code will take adjacent columns as specified in `usecols` to construct colors and use those as SOM inputs.  If set to `magandcolors` it will use the single column specfied by `ref_column_name` and the aforementioned colors to construct the SOM.  If set to `columns` then it will simply take each of the columns in `usecols` with no modification.  So, if a user wants to use K magnitudes and L colors, they can precompute the colors and specify all names in `usecols`.  NOTE: accompanying `usecols` you must have a `nondetect_val` dictionary that lists the replacement values for any non-detection-valued entries for each column, see the code for an example dictionary.  WE will set `column_usage` to colors and use only colors in this example notebook."
@@ -142,22 +145,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "a7653935",
    "metadata": {},
    "outputs": [],
    "source": [
+    "dim = 71\n",
     "grid_type = 'hexagonal'\n",
-    "inform_dict = dict(model='output_SOMoclu_model.pkl', hdf5_groupname='photometry',\n",
-    "                   n_rows=71, n_columns=71, \n",
+    "\n",
+    "\n",
+    "inform_dict = dict(model='output_SOMoclu_model.pkl', \n",
+    "                   hdf5_groupname='photometry',\n",
+    "                   n_rows=dim, n_columns=dim, \n",
     "                   gridtype = grid_type,\n",
+    "                   maptype = 'toroid',\n",
+    "                   n_epochs=30,\n",
     "                   std_coeff=12.0, som_learning_rate=0.75,\n",
     "                   column_usage='colors')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "1a5e5eb2",
    "metadata": {},
    "outputs": [],
@@ -201,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "cb956f69",
    "metadata": {},
    "outputs": [],
@@ -230,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "a9359dd1",
    "metadata": {},
    "outputs": [],
@@ -253,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "af1719a6",
    "metadata": {},
    "outputs": [],
@@ -337,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "239930bb",
    "metadata": {},
    "outputs": [],
@@ -360,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "968885c5",
    "metadata": {},
    "outputs": [],
@@ -397,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "f6e44d4e",
    "metadata": {},
    "outputs": [],
@@ -420,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "defa2827",
    "metadata": {},
    "outputs": [],
@@ -448,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "c6df12b7",
    "metadata": {},
    "outputs": [],
@@ -458,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "972a0f8d",
    "metadata": {},
    "outputs": [],
@@ -470,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "9fe847d4",
    "metadata": {},
    "outputs": [],
@@ -504,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "d19587e5",
    "metadata": {},
    "outputs": [],
@@ -530,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "10f284e6",
    "metadata": {},
    "outputs": [],
@@ -540,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "6809b439",
    "metadata": {},
    "outputs": [],
@@ -584,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "6e9c5e22",
    "metadata": {},
    "outputs": [],
@@ -634,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "2c622544",
    "metadata": {},
    "outputs": [],
@@ -644,7 +653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "82515f4e",
    "metadata": {},
    "outputs": [],
@@ -684,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "14f66fd7",
    "metadata": {},
    "outputs": [],

--- a/examples/estimation_examples/12_SomocluSOM_Quality_Control.ipynb
+++ b/examples/estimation_examples/12_SomocluSOM_Quality_Control.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "b187a115",
    "metadata": {},
    "outputs": [],
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "b8cc9628",
    "metadata": {},
    "outputs": [],
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "413b937a",
    "metadata": {},
    "outputs": [],
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "34082c32",
    "metadata": {},
    "outputs": [],
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "470ee4c8",
    "metadata": {},
    "outputs": [],
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "c988407f",
    "metadata": {},
    "outputs": [],
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "092295bf",
    "metadata": {},
    "outputs": [],
@@ -295,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "eb62dc29",
    "metadata": {},
    "outputs": [],
@@ -306,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "8822b434",
    "metadata": {},
    "outputs": [],
@@ -326,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "dd2d4573",
    "metadata": {},
    "outputs": [],
@@ -375,31 +375,38 @@
    "id": "51251f2d",
    "metadata": {},
    "source": [
-    "We need to define all of our necessary initialization params, which includes the following:<br>\n",
-    "`name` (str): the name of our estimator, as utilized by ceci<br>\n",
-    "`model` (str): the name for the model file containing the SOM and associated parameters that will be written by this stage<br>\n",
-    "`hdf5_groupname` (str): name of the hdf5 group (if any) where the photometric data resides in the training file<br>\n",
-    "`n_rows` (int): the number of dimensions in the y-direction for our 2D SOM<br>\n",
-    "`m_columns` (int): the number of dimensions in the x-direction for our 2D SOM<br>\n",
-    "`som_iterations` (int): the number of iteration steps during SOM training.  SOMs can take a while to converge, so we will use a fairly large number of 500,000 iterations.<br>\n",
-    "`std_coeff` (float): the \"radius\" of how far to spread changes in the SOM <br>\n",
-    "`som_learning_rate` (float): a number between 0 and 1 that controls how quickly the weighting function decreases.  SOM's are not guaranteed to converge mathematically, and so this parameter tunes how the response drops per iteration.  A typical values we might use might be between 0.5 and 0.75.<br>\n",
-    "`column_usage` (str):  this value determines what values will be used to construct the SOM, valid choices are `colors`, `magandcolors`, and `columns`.  If set to `colors`, the code will take adjacent columns as specified in `usecols` to construct colors and use those as SOM inputs.  If set to `magandcolors` it will use the single column specfied by `ref_column_name` and the aforementioned colors to construct the SOM.  If set to `columns` then it will simply take each of the columns in `usecols` with no modification.  So, if a user wants to use K magnitudes and L colors, they can precompute the colors and specify all names in `usecols`.  NOTE: accompanying `usecols` you must have a `nondetect_val` dictionary that lists the replacement values for any non-detection-valued entries for each column, see the code for an example dictionary.  WE will set `column_usage` to colors and use only colors in this example notebook."
+    "We need to define all of our necessary initialization params, which includes the following:\n",
+    "- `name` (str): the name of our estimator, as utilized by ceci\n",
+    "- `model` (str): the name for the model file containing the SOM and associated parameters that will be written by this stage\n",
+    "- `hdf5_groupname` (str): name of the hdf5 group (if any) where the photometric data resides in the training file\n",
+    "- `n_rows` (int): the number of dimensions in the y-direction for our 2D SOM\n",
+    "- `n_columns` (int): the number of dimensions in the x-direction for our 2D SOM\n",
+    "- `gridtype` (str): the parameter that specifies the grid form of the nodes. Options: `rectangular`(default) and `hexagonal`.\n",
+    "- `initialization` (str): the parameter specifying the method of initializing the SOM. Options: `pca`: principal componant analysis (default); `random`: randomly initialize the SOM.\n",
+    "- `maptype` (str): the parameter specifying the map topology. Options: `planar`(default) and `toroid`.\n",
+    "- `n_epochs` (int): the number of iteration steps during SOM training.  SOMs can take a while to converge, so we will use a fairly large number of 500,000 iterations.\n",
+    "- `std_coeff` (float): the \"radius\" of how far to spread changes in the SOM \n",
+    "- `som_learning_rate` (float): a number between 0 and 1 that controls how quickly the weighting function decreases.  SOM's are not guaranteed to converge mathematically, and so this parameter tunes how the response drops per iteration.  A typical values we might use might be between 0.5 and 0.75.\n",
+    "- `column_usage` (str):  this value determines what values will be used to construct the SOM, valid choices are `colors`, `magandcolors`, and `columns`.  If set to `colors`, the code will take adjacent columns as specified in `usecols` to construct colors and use those as SOM inputs.  If set to `magandcolors` it will use the single column specfied by `ref_column_name` and the aforementioned colors to construct the SOM.  If set to `columns` then it will simply take each of the columns in `usecols` with no modification.  So, if a user wants to use K magnitudes and L colors, they can precompute the colors and specify all names in `usecols`.  NOTE: accompanying `usecols` you must have a `nondetect_val` dictionary that lists the replacement values for any non-detection-valued entries for each column, see the code for an example dictionary.  WE will set `column_usage` to colors and use only colors in this example notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "d60262b5",
    "metadata": {},
    "outputs": [],
    "source": [
     "dim = 101\n",
-    "\n",
     "grid_type = 'hexagonal'\n",
-    "inform_dict = dict(model='output_SOMoclu_model.pkl', hdf5_groupname='photometry',\n",
+    "\n",
+    "\n",
+    "inform_dict = dict(model='output_SOMoclu_model.pkl', \n",
+    "                   hdf5_groupname='photometry',\n",
     "                   n_rows=dim, n_columns=dim, \n",
     "                   gridtype = grid_type,\n",
+    "                   maptype = 'toroid',\n",
+    "                   n_epochs=30,\n",
     "                   std_coeff=12.0, som_learning_rate=0.75,\n",
     "                   column_usage='colors')\n",
     "\n",
@@ -419,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "587dc808",
    "metadata": {},
    "outputs": [],
@@ -478,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "57eb95cf",
    "metadata": {},
    "outputs": [],
@@ -499,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "5862c293",
    "metadata": {},
    "outputs": [],
@@ -518,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "d0d876b2",
    "metadata": {},
    "outputs": [],
@@ -538,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "d0174a09",
    "metadata": {},
    "outputs": [],
@@ -566,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "1ac40ae2",
    "metadata": {},
    "outputs": [],
@@ -716,7 +723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "b33c9bd2",
    "metadata": {},
    "outputs": [],
@@ -1091,6 +1098,7 @@
     "fig, ax = plt.subplots(1,1)\n",
     "ax.boxplot(data, vert = 0)\n",
     "ax.axvline(0,1,0, color='C0')\n",
+    "ax.set_xlim(-0.02,0.02)\n",
     "ax.set_xlabel(r'$\\Delta\\left\\langle z \\right\\rangle$')\n",
     "ax.set_yticklabels(['SOM N(z), QC1+QC2', 'SOM N(z), QC2','SOM N(z), QC1', 'SOM N(z)'])"
    ]
@@ -1189,7 +1197,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python39",
+   "display_name": "RAIL",
    "language": "python",
    "name": "python3"
   },
@@ -1203,7 +1211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.12.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

I updated the instruction cell for the configuration of the informer so that the names match that in `SOMocluInformer`.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
