### PR TITLE
Update BPZ demo notebooks #191

### DIFF
--- a/examples/estimation_examples/02_BPZ_lite.ipynb
+++ b/examples/estimation_examples/02_BPZ_lite.ipynb
@@ -393,7 +393,9 @@
    "source": [
     "## BPZliteInformer: training a custom prior\n",
     "\n",
-    "If you want to go beyond the default prior, there is an `BPZliteInformer` stage that allows you to use a training dataset to fit a custom parameterized prior that better matches the magnitude and type distributions of the training set.\n",
+    "If you want to go beyond the default prior, there is an `BPZliteInformer` stage that allows you to use a training dataset to fit a custom parameterized prior that better matches the magnitude and type distributions of the training set.  As a major caveat, this inform stage does not always converge to sensible results, and **should ouly be run on a representative set of training data**.  As such, we do not anticipate that this will be run in full very often, and the *default* behavior of this method will be to simply return the default Hubble Deep Field North (HDFN) prior normalized to the type mix specified via the `nt_array` configuration parameter.  \n",
+    "\n",
+    "The `BPZliteInformer` configuration parameter `output_hdfn` controls the behavior of the `inform` stage.  By default it is set to `True`, which, as stated above, will not perform a fit, but instead just returns the HDFN prior parameters.  If `output_hdfn` is set to `False`, and a broad type file is supplied, then a full fit to new prior parameters is performed, as described below:\n",
     "\n",
     "`bpz-1.99.3` and our local fork, `DESC_BPZ` both parameterize the Bayesian prior using the form described in Benitez (2000), where the individual SED types are grouped into \"broad types\", e.g. 1 Elliptical makes up one type, the two spirals (Sbc and Scd) make up a second, and the five remaining \"blue\" templates (Im, SB3, SB2, ssp25Myr, and ssp5Myr) make up a third type.  This grouping is somewhat ad-hoc, but does have physical motivation, in that we have observed that Ellipticals, spirals, and irregular/starburst galaxies do show distinctly evolving observed fractions as a function of apparent/absolute magnitude and redshift.  Things get more complicated with more complex SED sets that contain variations in dust content, star formation histories, emission lines, etc...  Due to such complications, the **current** implementation of `BPZliteInformer` leaves the assignment of a \"broad-SED-type\" to the user, and these broad types are a necessary input to `BPZliteInformer` via the `type_file` config option.  In the future, determination of broad SED type will be added as a pre-processing step to the rail_bpz package.\n",
     "\n",
@@ -436,7 +438,7 @@
    "source": [
     "train_dict = dict(hdf5_groupname=\"photometry\", model=\"test_9816_demo_prior.pkl\",\n",
     "                 type_file=os.path.join(RAILDIR, \"rail/examples_data/estimation_data/data/test_dc2_training_9816_broadtypes.hdf5\"),\n",
-    "                 nt_array=[1,2,5])\n",
+    "                 nt_array=[1,2,5], output_hdfn=False)\n",
     "run_bpz_train = BPZliteInformer.make_stage(name=\"bpz_new_prior\", **train_dict)"
    ]
   },
@@ -841,7 +843,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "RAIL",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -855,7 +857,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/examples/estimation_examples/03_BPZ_lite_Custom_SEDs.ipynb
+++ b/examples/estimation_examples/03_BPZ_lite_Custom_SEDs.ipynb
@@ -176,7 +176,7 @@
     "                  spectra_file=\"baddc2templates.list\",\n",
     "                  type_file=os.path.join(RAILDIR, \"rail/examples_data/estimation_data/data/test_dc2_train_customtemp_broadttypes.hdf5\"),\n",
     "                  prior_band=\"mag_i_lsst\",\n",
-    "                  nt_array=[2,3,4])\n",
+    "                  nt_array=[2,3,4], output_hdfn=False)\n",
     "run_bpz_train = BPZliteInformer.make_stage(name=\"bpz_custom_sed_prior\", **train_dict)"
    ]
   },
@@ -578,7 +578,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
addresses #191 adds the output_hdfn param to the two demo BPZ notebooks to keep behavior consistent.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
