### PR TITLE
When there is smoke something is on fire

### DIFF
--- a/examples/estimation_examples/01_FlexZBoost_PDF_Representation_Comparison.ipynb
+++ b/examples/estimation_examples/01_FlexZBoost_PDF_Representation_Comparison.ipynb
@@ -218,8 +218,7 @@
     "\n",
     "plt.hist(fz_medians_qp_flexzboost, bins=np.linspace(-.005,3.005,101));\n",
     "plt.xlabel(\"redshift\")\n",
-    "plt.ylabel(\"Number\")\n",
-    "bins = np.linspace(-5, 5, 11)"
+    "plt.ylabel(\"Number\")"
    ]
   },
   {
@@ -236,7 +235,7 @@
    "outputs": [],
    "source": [
     "%%timeit\n",
-    "bins = np.linspace(-5, 5, 11)\n",
+    "bins = np.linspace(0, 3, 301)\n",
     "fzresults_qp_flexzboost().convert_to(qp.hist_gen, bins=bins)"
    ]
   },
@@ -356,7 +355,7 @@
    "outputs": [],
    "source": [
     "%%timeit\n",
-    "bins = np.linspace(-5, 5, 11)\n",
+    "bins = np.linspace(0, 3, 301)\n",
     "fzresults_qp_interp().convert_to(qp.hist_gen, bins=bins)"
    ]
   },

--- a/examples/estimation_examples/14_LePhare_LSST.ipynb
+++ b/examples/estimation_examples/14_LePhare_LSST.ipynb
@@ -99,6 +99,7 @@
     "    zmin=0,\n",
     "    zmax=3,\n",
     "    nzbins=31,\n",
+    "    lephare_config = lephare_config # this is important if you want to modify your default setup with the parameter file\n",
     ")\n",
     "inform_lephare.inform(traindata_io)"
    ]
@@ -235,9 +236,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "rail_env",
    "language": "python",
-   "name": "python3"
+   "name": "rail_env"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
bug 1: the flexzboost_gen saves the yvals of the CDF once the cdf() is called, but if the user changes to a different grid value, it doesn't re-compute. Now forcing _compute_ycumul() to execute everytime cdf is called, it fixes the bug. This is linked the smoke failure in rail-hub, see [](https://github.com/LSSTDESC/qp_flexzboost/pull/33) 

bug 2: Lephare stages are not correctly ingesting the parameters. We were getting away with it because the default config works, now that it don't we need to properly override. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
