### PR TITLE
Adding info on how to configure input catalogues for a single stage

### DIFF
--- a/docs/source/catalog_tags.rst
+++ b/docs/source/catalog_tags.rst
@@ -24,10 +24,10 @@ catalog may have band names like "{band}_gaap1p0Mag", which is different from th
 default values in RAIL. To set this in `MyFavouriteInformer`, do 
 `MyFavouriteEstimator.make_stage(band = [f"{band}_gaap1p0Mag" for band in "ugrizy"])`. 
 Note that typically a stage may require changes in multiple input parameters 
-(e.g. `err_bands` and `ref_bands` needs to be changed accordingly.
-Note also that if you want to run `MyFavouriteEstimator` next, you will need to repeat
-this for the `make_stage` for the estimator. This is why, in case you are running
-many stages, shared parameters below are preferred.
+(e.g. `err_bands` and `ref_bands` needs to be changed accordingly).
+Note also that if the user wants to run `MyFavouriteEstimator` next, they will need to repeat
+this for the `make_stage` for the estimator. This is why, in case the user is running
+many stages, using shared parameters below are preferred.
 
 =================
 Shared Parameters

--- a/docs/source/catalog_tags.rst
+++ b/docs/source/catalog_tags.rst
@@ -17,9 +17,17 @@ a particular source, rather than having to edit the configurations
 for many different `RailStages`.
 
 When using a single stage (e.g. testing an algorithm in a Jupyter notebook), 
-it is also possible to overwrite the default settings for the input data. 
-In the `make_stage` step, simply specify catalog information. An simple example is 
-changing the band names of the input catalog from the default values to Gaap magnitudes, in `MyFavouriteEstimator`. This can be done by simply setting `MyFavouriteEstimator.make_stage(band = [f"{band}_gaap1p0Mag" for band in "ugrizy"])`. Note that typically a stage may require changes in multiple input parameters (e.g. `err_bands` and `ref_bands` needs to be changed accordingly.
+it is also possible to overwrite the default settings for the input data
+directly for the stage, without involving the shared parameters, by simply 
+specifying catalog information in the `make_stage` step. For example, your input
+catalog may have band names like "{band}_gaap1p0Mag", which is different from the 
+default values in RAIL. To set this in `MyFavouriteInformer`, do 
+`MyFavouriteEstimator.make_stage(band = [f"{band}_gaap1p0Mag" for band in "ugrizy"])`. 
+Note that typically a stage may require changes in multiple input parameters 
+(e.g. `err_bands` and `ref_bands` needs to be changed accordingly.
+Note also that if you want to run `MyFavouriteEstimator` next, you will need to repeat
+this for the `make_stage` for the estimator. This is why, in case you are running
+many stages, shared parameters below are preferred.
 
 =================
 Shared Parameters

--- a/docs/source/catalog_tags.rst
+++ b/docs/source/catalog_tags.rst
@@ -16,6 +16,11 @@ sub-classes we have made it simple configure `RAIL` to read data from
 a particular source, rather than having to edit the configurations
 for many different `RailStages`.
 
+When using a single stage (e.g. testing an algorithm in a Jupyter notebook), 
+it is also possible to overwrite the default settings for the input data. 
+In the `make_stage` step, simply specify catalog information. An simple example is 
+changing the band names of the input catalog from the default values to Gaap magnitudes, in `MyFavouriteEstimator`. This can be done by simply setting `MyFavouriteEstimator.make_stage(band = [f"{band}_gaap1p0Mag" for band in "ugrizy"])`. Note that typically a stage may require changes in multiple input parameters (e.g. `err_bands` and `ref_bands` needs to be changed accordingly.
+
 =================
 Shared Parameters
 =================


### PR DESCRIPTION
## Problem & Solution Description
There are requests to clarify how to change default parameters for the input catalogue for a single stage. This PR hence adds a short paragraph on this, in addition to the shared_params methods which is the preferred method for running multiple stages.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
