### PR TITLE
Demo NB with different dataset and overrides #200

### DIFF
--- a/examples/estimation_examples/15_Running_with_different_data.ipynb
+++ b/examples/estimation_examples/15_Running_with_different_data.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Running RAIL with a different dataset\n",
+    "\n",
+    "**Authors:** Sam Schmidt\n",
+    "\n",
+    "**Last run successfully:** September 24, 2025"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a notebook with a quick example of running a `rail` algoritm with a different dataset and overriding configuration parameters.  \n",
+    "\n",
+    "Most of our other demo notebooks use small datasets included with the RAIL demo package, all with the same input names.  These datasets are named consistently with many of the default parameter values used in RAIL, e.g. `hdf5_groupname=\"photometry\"` and ugrizy photometry named in a pattern `\"mag_{band}_lsst\"`, often specified in `SHARED_PARAMS`.  \n",
+    "\n",
+    "This notebook will just show a quick run with an alternate dataset, showing the values that users will likely need to change in order to get things running.  \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import tables_io"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we'll start with grabbing some small datasets from NERSC, a tar file with some data drawn from the Roman-Rubin simulation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_file = \"./romanrubin_demo_data.tar\"\n",
+    "\n",
+    "if not os.path.exists(training_file):\n",
+    "  os.system('curl -O https://portal.nersc.gov/cfs/lsst/PZ/romanrubin_demo_data.tar')\n",
+    "  os.system('tar -xvf romanrubin_demo_data.tar')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's load one of the files and look at the contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "infile = \"romanrubin_train_data.hdf5\"\n",
+    "data = tables_io.read(infile)\n",
+    "data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that, unlike the demo data in other notebooks, there is no top level hdf5_groupname of \"photometry\", the data is directly in the top level of the hdf5 file.  As such, we will need to specify `hdf5_groupname=\"\"` to override the default value of `\"photometry\"` in RAIL.\n",
+    "\n",
+    "We also see that the magnitudes and errors are simply named with the band name, e.g. `\"u\"` rather than `\"mag_u_lsst\"`.  Again, we will need to specify the band and error names in order to override the defaults in RAIL.  Let's do that below, using the KNearNeighInformer and Estimator algorithms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rail.core.data import TableHandle\n",
+    "from rail.core.stage import RailStage\n",
+    "from rail.estimation.algos.k_nearneigh import KNearNeighInformer, KNearNeighEstimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainFile = \"./romanrubin_train_data.hdf5\"\n",
+    "testFile = \"./romanrubin_test_data.hdf5\"\n",
+    "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
+    "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The dataset-specific parameters\n",
+    "\n",
+    "We will need to specify several  parameters to override the default values in RAIL, we can create a dictionary of these and pass those into the `make_stage` for our informer.  Because we have Roman J and H, we will also demonstrate running with 8 bands rather than the default six.\n",
+    "\n",
+    "RAIL requires that we specify the names of the input columns as `bands`, and the input errors on those as `err_bands`.  Most algorithms also require a `ref_band`.  To handle non-detections, RAIL uses a dictionary of `mag_limits` which must contain keys for all of the columns in `bands` and a float for the value with which the non-detect will be replaced.  You may also need to specify a different `nondetect_val` if the dataset has a different convention for non-detections (in this dataset, our non-detetions have a value of `np.inf`).  Let's set up our dictionary with these values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bands = ['u', 'g', 'r', 'i', 'z', 'y', 'J', 'H']\n",
+    "errbands = []\n",
+    "maglims = {}\n",
+    "limvals = [27.8, 29.0, 29.1, 28.6, 28.0, 27.0, 26.4, 26.4]\n",
+    "for band, limval in zip(bands, limvals):\n",
+    "    errbands.append(f\"{band}_err\")\n",
+    "    maglims[band] = limval\n",
+    "\n",
+    "\n",
+    "print(bands)\n",
+    "print(errbands)\n",
+    "print(maglims)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "knn_dict = dict(hdf5_groupname='', bands=bands, err_bands=errbands, mag_limits=maglims, ref_band='i')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now feed this into our inform stage:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pz_train = KNearNeighInformer.make_stage(name='inform_KNN', model='rd_demo_knn.pkl', **knn_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pz_train.inform(training_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the same dictionary to specify overrides for the estimator stage:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pz = KNearNeighEstimator.make_stage(name='KNN', model=pz_train.get_handle('model'), **knn_dict)\n",
+    "results = pz.estimate(test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot the mode vs the true redshift to make sure that things ran properly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zmode = results().ancil['zmode'].flatten()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot the redshift mode against the true redshifts to see how they look:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8,8))\n",
+    "plt.scatter(test_data()['redshift'],zmode,s=1,c='k',label='KNN mode')\n",
+    "plt.plot([0,3],[0,3],'r--');\n",
+    "plt.xlabel(\"true redshift\")\n",
+    "plt.ylabel(\"KNN mode\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Yes, things look very nice, and the inclusion of NIR photometry gives us very little scatter and very few outliers!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/estimation_examples/16_Running_with_different_data.ipynb
+++ b/examples/estimation_examples/16_Running_with_different_data.ipynb
@@ -123,7 +123,11 @@
     "\n",
     "We will need to specify several  parameters to override the default values in RAIL, we can create a dictionary of these and pass those into the `make_stage` for our informer.  Because we have Roman J and H, we will also demonstrate running with 8 bands rather than the default six.\n",
     "\n",
-    "RAIL requires that we specify the names of the input columns as `bands`, and the input errors on those as `err_bands`.  Most algorithms also require a `ref_band`.  To handle non-detections, RAIL uses a dictionary of `mag_limits` which must contain keys for all of the columns in `bands` and a float for the value with which the non-detect will be replaced.  You may also need to specify a different `nondetect_val` if the dataset has a different convention for non-detections (in this dataset, our non-detetions have a value of `np.inf`).  Let's set up our dictionary with these values:"
+    "RAIL requires that we specify the names of the input columns as `bands`, and the input errors on those as `err_bands`.  Most algorithms also require a `ref_band`.  To handle non-detections, RAIL uses a dictionary of `mag_limits` which must contain keys for all of the columns in `bands` and a float for the value with which the non-detect will be replaced.  You may also need to specify a different `nondetect_val` if the dataset has a different convention for non-detections (in this dataset, our non-detetions have a value of `np.inf`).  \n",
+    "\n",
+    "**NOTE:** RAIL uses `SHARED_PARAMS`, a central location for specifying a subset of parameters that are common to a dataset, and setting them in one place when running multiple algorithms.  However, any configuration parameters specified as `SHARED_PARAMS` can be overridden in the same way as any other parameter, there is nothing special about them, and we will do that here with `bands`, `err_bands`, etc...\n",
+    "\n",
+    "Let's set up our dictionary with these values:"
    ]
   },
   {


### PR DESCRIPTION
Adds a quick demo notebook that runs KNN on some Roman-Rubin data with different band names, demonstrates overriding the config parameters. Addresses #200 

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
