### PR TITLE
Add details on how to run create_interactive_structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # RAIL: Redshift Assessment Infrastructure Layers
 
 RAIL is a flexible software library providing tools to produce at-scale photometric redshift data products, including uncertainties and summary statistics, and stress-test them under realistically complex systematics.
-A detailed description of RAIL's modular structure is available in the [Overview](https://rail-hub.readthedocs.io/en/latest/source/overview.html) on ReadTheDocs.
+A detailed description of RAIL's modular structure is available in the [Overview](https://rail-hub.readthedocs.io/en/latest/source/user_guide/what_is_rail.html) on ReadTheDocs.
 
 RAIL serves as the infrastructure supporting many extragalactic applications of the Legacy Survey of Space and Time (LSST) on the Vera C. Rubin Observatory, including Rubin-wide commissioning activities. 
 RAIL was initiated by the Photometric Redshifts (PZ) Working Group (WG) of the LSST Dark Energy Science Collaboration (DESC) as a result of the lessons learned from the [Data Challenge 1 (DC1) experiment](https://academic.oup.com/mnras/article/499/2/1587/5905416) to enable the PZ WG Deliverables in [the LSST-DESC Science Roadmap (see Sec. 5.18)](https://lsstdesc.org/assets/pdf/docs/DESC_SRM_latest.pdf), aiming to guide the selection and implementation of redshift estimators in DESC analysis pipelines.
@@ -15,11 +15,11 @@ RAIL is developed and maintained by a diverse team comprising DESC Pipeline Scie
 
 ## Installation
 
-Installation instructions are available under [Installation](https://rail-hub.readthedocs.io/en/latest/source/installation.html) on ReadTheDocs.
+Installation instructions are available under [Installation](https://rail-hub.readthedocs.io/en/latest/source/user_guide/installation.html) on ReadTheDocs.
 
 ## Contributing
 
-The greatest strength of RAIL is its extensibility; those interested in contributing to RAIL should start by consulting the [Contributing guidelines](https://rail-hub.readthedocs.io/en/latest/source/contributing.html) on ReadTheDocs.
+The greatest strength of RAIL is its extensibility; those interested in contributing to RAIL should start by consulting the [Contributing guidelines](https://rail-hub.readthedocs.io/en/latest/source/development/contribute_to_rail.html) on ReadTheDocs.
 
 ## Citing RAIL
 
@@ -44,5 +44,5 @@ archivePrefix = {arXiv},
 }
 ```
 Please consider also inviting the developers as co-authors on publications resulting from your use of RAIL by [making an issue](https://github.com/LSSTDESC/rail/issues/new/choose).
-A convenient list of what to cite may be found under [Citing RAIL](https://rail-hub.readthedocs.io/en/latest/source/citing.html) on ReadTheDocs.
+A convenient list of what to cite may be found under [Citing RAIL](https://rail-hub.readthedocs.io/en/latest/source/user_guide/citations.html) on ReadTheDocs.
 Additionally, several of the codes accessible through the RAIL ecosystem must be cited if used in a publication.

--- a/docs/source/development/contribute_to_rail.rst
+++ b/docs/source/development/contribute_to_rail.rst
@@ -135,7 +135,10 @@ conflicts.
     available to users of the interactive module. This script must be run in 
     a clean environment (i.e. with packages pip installed and only updated to their latest 
     release). One easy way to do this is to use the `RAIL docker image
-    <https://github.com/LSSTDESC/rail_setup/pkgs/container/desc-rail>`_.  
+    <https://github.com/LSSTDESC/rail_setup/pkgs/container/desc-rail>`_. When doing a PR, the 
+    `create_interactive_structure` workflow will run the script and compare it to the files in 
+    your PR. If they don't match, the last few lines will list the files that have been modified, 
+    which are the the files that are causing the issues. 
 
 
 Reviewing a PR

--- a/docs/source/development/contribute_to_rail.rst
+++ b/docs/source/development/contribute_to_rail.rst
@@ -132,7 +132,10 @@ conflicts.
     The changes made in this PR will be (in addition to any others needed for your
     update) the results of running the ``create_interactive_structure.py`` script
     present in ``rail_base``. This script updates the stub files and thus docstrings
-    available to users of the interactive module.
+    available to users of the interactive module. This script must be run in 
+    a clean environment (i.e. with packages pip installed and only updated to their latest 
+    release). One easy way to do this is to use the `RAIL docker image
+    <https://github.com/LSSTDESC/rail_setup/pkgs/container/desc-rail>`_.  
 
 
 Reviewing a PR

--- a/docs/source/development/contribute_to_rail.rst
+++ b/docs/source/development/contribute_to_rail.rst
@@ -49,7 +49,7 @@ and/or making a new one.
 Similar to the installation process, depending on how you want to contribute to
 RAIL, you will be contributing to one or more of the RAIL packages.
 
-In all cases, begin by following the :ref:`developer installation instructions <Developer Installation>`
+In all cases, begin by following the :ref:`developer installation instructions <Developer Installation Instructions>`
 and follow the contribution workflow instructions below.
 
 
@@ -77,7 +77,7 @@ that repository.
 Branch
 ------
 
-See :ref:`Developer Installation` for installation instructions.
+See :ref:`Developer Installation Instructions` for installation instructions.
 
 While developing in a branch, don't forget to pull from ``main`` regularly (at
 least daily) to make sure your work is compatible with other recent changes.

--- a/docs/source/development/contributor_concepts.rst
+++ b/docs/source/development/contributor_concepts.rst
@@ -248,7 +248,7 @@ will have ``__init__.py`` files created within the interactive directory.
 Instead, modifications should be made either to that creation script, or to the
 functions in the utility folder ``rail_base/src/rail/utils/interactive``.
 
-All subclasses of RailStage are considered valid candidates to have interative
+All subclasses of RailStage are considered valid candidates to have interactive
 functions, and it is thus an error for a ``RailStage`` to lack the required
 infrastructure to have an interactive function generated. See the notes on
 :ref:`adding new stages<page-add-stage>` regarding requirements and best practices when

--- a/docs/source/development/developer_installation.rst
+++ b/docs/source/development/developer_installation.rst
@@ -1,3 +1,5 @@
+.. _page-developer-installation:
+
 ***********************************
 Developer Installation Instructions
 ***********************************

--- a/docs/source/interactive_api_content/rail.interactive.rst
+++ b/docs/source/interactive_api_content/rail.interactive.rst
@@ -6,4 +6,7 @@ have viewable source code.
 
 The docstrings given below are created from the RailStage classes and their primary
 method (called the *entrypoint function*), and can be seen by users by inspecting the
-function objects.
+function objects. 
+
+They are updated along with pz-rail-base, but the content of them is generated from the algorithm packages, using the versions that were available when this documentation was generated.
+Therefore, if your installed version of pz-rail-base differs from the current version, this documentation *may* not match the docstrings available on your machine.

--- a/docs/source/user_guide/interactive_usage.rst
+++ b/docs/source/user_guide/interactive_usage.rst
@@ -313,4 +313,4 @@ Additionally, it is possible that the algorithm packages on your machine differ 
 1. Ensure that you have the latest release version of pz-rail-base installed
 2. If you have a specific package whose docstrings are incorrect, try upgrading to the latest released version of that package (or possibly downgrading, if you've installed via git clone.)
 
-If you are still having issues, please notify #pz-rail. You can also use the documentation of the corresponding class-based RAIL stage to identify the correct parameters.
+If you are still having issues, please notify the RAIL team. You can also use the documentation of the corresponding class-based RAIL stage to identify the correct parameters.

--- a/docs/source/user_guide/interactive_usage.rst
+++ b/docs/source/user_guide/interactive_usage.rst
@@ -298,3 +298,19 @@ You can now turn the array into a table or save it to a file directly using your
     If you have any examples that you think should be added to this list, you can open an `issue <https://github.com/LSSTDESC/rail/issues/new/choose>`_ 
     in RAIL, or if you are a part of the LSST Slack, send a message in the `\#desc-pz-rail
     <https://lsstc.slack.com/archives/CQGKM0WKD>`_ Slack channel! 
+
+
+===============
+Troubleshooting
+===============
+
+The interactive API docs are updated along with pz-rail-base, but the content of them is generated from the algorithm packages, using the versions that were available when this documentation was generated.
+
+Therefore, if your installed version of pz-rail-base differs from the current version, this documentation *may* not match the docstrings available on your machine.
+
+Additionally, it is possible that the algorithm packages on your machine differ from those that were available when this documentation was generated (e.g., if you have updated a pz-rail-<algorithm> package). In this case, the docstrings on your computer *may* be out of date. If you have issues regarding incorrect docstrings, try the following:
+
+1. Ensure that you have the latest release version of pz-rail-base installed
+2. If you have a specific package whose docstrings are incorrect, try upgrading to the latest released version of that package (or possibly downgrading, if you've installed via git clone.)
+
+If you are still having issues, please notify #pz-rail. You can also use the documentation of the corresponding class-based RAIL stage to identify the correct parameters.


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
- There were not enough details on how to run this script to get it to work properly with the workflow that runs it on github. This information has been added to the 'Contribute to RAIL' page of the documentation
- fixed some links in the README and in developer docs 
- added some troubleshooting info for interactive docstrings 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
