### PR TITLE
Add a notebook demo for new bpz zero point and broad types

### DIFF
--- a/pipeline_examples/estimation_examples/17_BPZ_zeropoint_shifts_and_broad_types.ipynb
+++ b/pipeline_examples/estimation_examples/17_BPZ_zeropoint_shifts_and_broad_types.ipynb
@@ -1,0 +1,623 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2ac442d9",
+   "metadata": {},
+   "source": [
+    "# BPZ Lite: determining zero point shifts and braod types\n",
+    "\n",
+    "**Authors:** Sam Schmidt\n",
+    "\n",
+    "**Last Successfully Run:** Jun 05, 2026"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85906442-6d29-407a-8d80-4108d45af015",
+   "metadata": {},
+   "source": [
+    "This notebook will go through a simple example of running a new \"pre-estimation\" stage that does two things:\n",
+    "- Compute zero point offsets to the photometric bands\n",
+    "- computes \"broad types\" for the galaxy sample that can be used to train a custom prior in the inform stage\n",
+    "\n",
+    "**Note:** The zero point shift coded up here is different from the one in the original BPZ code, this simply finds the mean offset between the best-fit redshift and type fluxes and the measured fluxes, i.e. \"shifting\" the mean colors to line up with the best fit templates.  Note that the template, and thus flux, of the \"best fit\" object can change once a zero point shift has been applied, particularly if they are large shifts.  So, this stage may need to be run iteratively to get the \"final\" zero point shifts.\n",
+    "\n",
+    "**Be wary of large shifts!** Zero point shifts should be small, due to slight miscalibrations of photometry, differences between aperture and total mags, etc... If the code predicts very large zero point offsets of more than ~0.1-0.2 mags, then something else could be wrong.  Do not blindly apply shifts that are output by the code!\n",
+    "\n",
+    "**For best results, this should be run with spectroscopic data with secure redshifts and with the `only_type` parameter set to `True`**\n",
+    "\n",
+    "For the broad types determination, what the code is doing is finding the best-fit SED for each galaxy.  It then looks at `nt_array` to check how the SED list used by BPZ is being mapped to broad type.  For example, the default `nt_array` for the default CWWSB template set is `[1, 2, 5]`, which means that there are 8 total templates, 1 Elliptical (El_B2004a), 2 Spiral (Sbc_B2004a and Scd_B2004a), and 5 Irregular/Starburst SEDs (Im_B2004, SB3_B2004a, SB2_B2004a, ssp_25Myr_z008, and ssp_5Myr_z008).  It will take the best-fit SEDs and return an integer corresponding to which of the \"broad types\" that corresponds to, in this case 0, 1, or 2 for El, Sp, or Im/SB.  \n",
+    "**This should be run with `only_type` set to `True`**: if you attempt to run without true redshifts, BPZ will essentially run a prior-free likelihood computation and assign the best type to the peak likelihood.  Given the many degeneracies tha occur in photo-z fitting, this can lead to wildly different type fits, and thus should be avoided.\n",
+    "\n",
+    "The list of zero point offsets and broad types are output as an hdf5 file.  They will be stored in separate hdf5 groups, the zero point offsets  as `offsets/zp_offsets` and the broad types as `types/broad_type`\n",
+    "\n",
+    "A final warning: most spectroscopic datasets are very systematically incomplete, and thus trying to run a custom prior can be fraught with problems.  I do not expect broad_types and custom priors to be computed very often.  \n",
+    "### **Using the default HDFN prior rather than computing your own prior is highly recommended in almost every case**\n",
+    "\n",
+    "\n",
+    "## Example: add some offsets to data and test zero-point correction\n",
+    "\n",
+    "We will run a quick demo where we read in the same example data used in notebooks 02 and 03 for the main BPZ tests, and we'll add offsets to the g and z bands, then run our zero-point correction code to see how well it does at finding those offsets.\n",
+    "\n",
+    "The new stage is located in `src/rail/estimation/algos/bpz_preprocess.py` and the stage name is `BPZlitePreEstimator` (since it needs to be run before estimation):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69b30a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import qp\n",
+    "import tables_io\n",
+    "import pickle\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import desc_bpz\n",
+    "from rail.core.data import TableHandle, ModelHandle\n",
+    "from rail.core.stage import RailStage\n",
+    "from rail.utils.path_utils import RAILDIR\n",
+    "from rail.estimation.algos.bpz_lite import BPZliteInformer, BPZliteEstimator\n",
+    "\n",
+    "from rail.estimation.algos.bpz_preprocess import BPZlitePreEstimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e57f155b-55ac-48a0-acff-2ebb2bdfceb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bands = [\"u\", \"g\", \"r\", \"i\", \"z\", \"y\"]\n",
+    "lsst_bands = []\n",
+    "lsst_errs = []\n",
+    "lsst_filts = []\n",
+    "for band in bands:\n",
+    "    lsst_bands.append(f\"mag_{band}_lsst\")\n",
+    "    lsst_errs.append(f\"mag_err_{band}_lsst\")\n",
+    "    lsst_filts.append(f\"DC2LSST_{band}\")\n",
+    "print(lsst_bands)\n",
+    "print(lsst_filts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ab08dcf-72d2-4a6f-8037-14301f922c17",
+   "metadata": {},
+   "source": [
+    "First, let's grab the training and test data files and add some offsets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1e74f88-a0d4-42af-a4ac-4deefd0c8cc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "training_data = tables_io.read(trainFile)\n",
+    "test_data = tables_io.read(testFile)\n",
+    "\n",
+    "training_data['photometry']['mag_g_lsst'] -= 0.15\n",
+    "training_data['photometry']['mag_z_lsst'] += 0.2\n",
+    "\n",
+    "test_data['photometry']['mag_g_lsst'] -= 0.15\n",
+    "test_data['photometry']['mag_z_lsst'] += 0.2\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "979d5363-af4e-4478-9820-29214292bf16",
+   "metadata": {},
+   "source": [
+    "Let's run BPZ on this shift file with no zero point offsets applied, results should look sub-optimal due to the g- and z-band shifts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9b5ca91-35e4-4895-8072-a620e57f7a10",
+   "metadata": {},
+   "source": [
+    "Now, let's set up a dictionary of configuration parameters and set up to run the estimator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a03c3e9f-7080-4334-bcf1-7993239b69db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdfnfile = os.path.join(RAILDIR, \"rail/examples_data/estimation_data/data/CWW_HDFN_prior.pkl\")\n",
+    "default_dict = dict(hdf5_groupname=\"photometry\", output=\"bpz_results_defaultprior.hdf5\",\n",
+    "                    bands=lsst_bands, err_bands=lsst_errs, filter_list=lsst_filts,\n",
+    "                    prior_band=\"mag_i_lsst\", no_prior=False)\n",
+    "run_default = BPZliteEstimator.make_stage(name=\"bpz_def_prior\", model=hdfnfile, **default_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81654659-3953-46f3-a927-09eb2963cb9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noshift_res = run_default.estimate(test_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2047179-6fdc-4e06-9592-eda1c465937b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zmode = noshift_res().mode(grid=np.linspace(0,3,301)).flatten()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0762a904-7997-43c9-aed8-33c61c5917b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(7,7))\n",
+    "plt.scatter(test_data['photometry']['redshift'], zmode, s=1, c='k')\n",
+    "plt.plot([0,3],[0,3], 'r--')\n",
+    "plt.xlabel(\"true redshift\", size=12)\n",
+    "plt.ylabel(\"z mode no zp correction\", size=12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "880eb42f-c346-4b43-a9a3-f2dc452e2bb5",
+   "metadata": {},
+   "source": [
+    "As expected, we see some extra bias ans horizontal features, as redshifts fits are biased by our zero-point shifts.\n",
+    "\n",
+    "Now let's run the `BPZlitePreEstimator` stage to determine our zero point offsets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6faecc1d-d348-486b-8550-b9639138f112",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zpt_tweak = BPZlitePreEstimator.make_stage(name=\"first pass\", only_type=True, \n",
+    "                                           output=\"bpz_offsets_firstpass.hdf5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b5cd587-122e-41ef-9d3f-77333a54c6bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "results = zpt_tweak.estimate(training_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1a15e67-25dd-4e05-b7e1-5b8262c2367a",
+   "metadata": {},
+   "source": [
+    "Let's see what offsets we came up with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "787dd889-9894-42f3-b5cb-06c71ced0d7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results().keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d914a91d-134d-4469-8b21-e196cc1218c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zpoff = np.array(results()['offsets']['zp_offsets'])\n",
+    "print(zpoff)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13c12c4a-ba7b-40e0-afea-51309f76d7bb",
+   "metadata": {},
+   "source": [
+    "We see an offset of -0.121 for the g band and +0.183 for the z band, similar to our applied offsets of -.15 and +0.20.  In addition, there are small 0.01-0.05 offsets for the other bands.\n",
+    "    \n",
+    "We are fitting data from the DC2 simulation with CWWSB templates.  The mismatch in SEDs between the \"true\" data and our SED models can lead to zero point offsets even with perfect photometry, as BPZ sees the difference in color as being due to bad photometry rather than mismatched SED models.  This is the danger inherent in zero point tweaks, it can confuse observational photometry effects with inherent differences between SED models, it is a zeroth order correction to a model misspecification with other causes.  But, it can often improve photo-z results, at least on the training data, so it does have its uses."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64c69fa8-3724-4025-b675-c4d5936385fe",
+   "metadata": {},
+   "source": [
+    "Note that we can re-run but now include an initial set of zero-point tweaks applied via the `zp_offsets` parameter. This will likely lead to better broad-type fit, and potential small updates to the zero points, this second pass will output the *total* zp_offset from the initial data, i.e. it will include the offsets from the initial step in the final offsets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ffcd76e-7603-49da-b76d-1b2056b6950e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zpt_type = BPZlitePreEstimator.make_stage(name=\"second pass\", only_type=True,\n",
+    "                                          zp_offsets=zpoff,\n",
+    "                                          output=\"bpz_offsets_secondpass.hdf5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d97d584-0b62-40f2-9396-b6960844a2f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "secpass_res = zpt_type.estimate(training_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bbda732-4b2d-4ad8-ab6b-4943906f6d67",
+   "metadata": {},
+   "source": [
+    "Let's see what our final offsets are:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "107455bf-0804-41c6-97d5-be4fb36a800d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zpoff_final = np.array(secpass_res()['offsets']['zp_offsets'])\n",
+    "print(zpoff_final)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a54ed352-e6ae-4697-bd6e-43f8ac926a58",
+   "metadata": {},
+   "source": [
+    "Looks good!  It wants a rather large correction to the u-band and y-band zeropoints (not uncommon to have the bluest and reddest bands needing some \"correction\" due to differences in SEDs), but we are now closer to our artificial offsets for g and z bands.\n",
+    "\n",
+    "We can also look at the broad_types that we computed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85cf8113-fb59-4986-a46a-99864fdb57e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "broad_types = secpass_res()['types']['broad_type']\n",
+    "print(broad_types[:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15d86793-d928-4adb-a72e-c207f993b633",
+   "metadata": {},
+   "source": [
+    "## Training a new prior (with zero point offsets)\n",
+    "\n",
+    "Let's compute a new prior with the zpt offsets, you can see notebook 02 for more detail on this if needed.  We will compute a new prior that will be written out as `new_hdfn_prior.pkl`.\n",
+    "\n",
+    "We will use the broad_types and zero point offsets from our file `bpz_offsets_secondpass.hdf5`.  There is a parameter `override_file_offsets`, if this is set to `True` you can override the offsets in the file and instead input offsets directly via a `zp_offsets` parameter.  We will **not** do that here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c28c9b6-6bf7-42a8-949a-2ea5a44fb5ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_dict = dict(hdf5_groupname=\"photometry\", model=\"new_prior.pkl\",\n",
+    "                 type_file=\"./bpz_offsets_secondpass.hdf5\",\n",
+    "                 override_file_offsets=False,\n",
+    "                 nt_array=[1,2,5], output_hdfn=False)\n",
+    "run_bpz_train = BPZliteInformer.make_stage(name=\"bpz_new_prior\", **train_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0fc63b8-e8b4-45cd-9abf-26b126b5d530",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "run_bpz_train.inform(training_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b09aa49a-3b10-4583-9a42-46c34e632df1",
+   "metadata": {},
+   "source": [
+    "We can compare our new prior to the default HDFN prior, similar to done in notebook 02.  First, the parameters of the HDFN model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b8f9d19-36d7-4d57-9f09-a251ce69c4e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from desc_bpz.prior_from_dict import prior_function\n",
+    "\n",
+    "\n",
+    "hdfnfile = os.path.join(RAILDIR, \"rail/examples_data/estimation_data/data/CWW_HDFN_prior.pkl\")\n",
+    "\n",
+    "with open(hdfnfile, \"rb\") as f:\n",
+    "    xhdfnmodel = pickle.load(f)\n",
+    "hdfnmodel = xhdfnmodel['priormodel']\n",
+    "xhdfnmodel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2dd68488-cf42-46b3-ae6c-db925bd7d720",
+   "metadata": {},
+   "source": [
+    "Now the parameters of our new model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51d1c69b-f05c-48f8-b0c9-8ccfc3216a90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"./new_prior.pkl\", \"rb\") as f:\n",
+    "    xnewmodel = pickle.load(f)\n",
+    "newmodel = xnewmodel['priormodel']\n",
+    "xnewmodel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df0fff91-c978-4f96-9772-8b99f95a1037",
+   "metadata": {},
+   "source": [
+    "We can plot up the prior at a couple of magnitudes to do a more visual comparison:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51c2460a-a37e-4613-9e6e-8df0bcdabf84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zgrid=np.linspace(0,3,301)\n",
+    "defprior20 = prior_function(zgrid, 20., hdfnmodel, 8)\n",
+    "defprior23 = prior_function(zgrid, 23., hdfnmodel, 8)\n",
+    "defprior25 = prior_function(zgrid, 25., hdfnmodel, 8)\n",
+    "newprior23 = prior_function(zgrid, 23., newmodel, 8)\n",
+    "newprior25 = prior_function(zgrid, 25., newmodel, 8)\n",
+    "newprior20 = prior_function(zgrid, 20., newmodel, 8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fbf0bbe-d192-4886-a683-6a593f1a8f47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seddict = {'El': 0, 'Sp': 1, 'Irr/SB': 7}\n",
+    "multiplier = [1.0, 2.0, 5.0]\n",
+    "sedcol = ['r', 'm', 'b']\n",
+    "fig, (axs, axs2, axs3) = plt.subplots(3, 1, figsize=(7,10))\n",
+    "for sed, col, multi in zip(seddict, sedcol, multiplier):\n",
+    "    axs.plot(zgrid, defprior20[:,seddict[sed]]*multi, color=col, lw=2,ls='--', label=f\"hdfn prior {sed}\")\n",
+    "    axs.plot(zgrid, newprior20[:,seddict[sed]]*multi, color=col, ls='-', label=f\"new prior {sed}\")\n",
+    "    axs.set_title(\"priors for mag=20.0\")\n",
+    "    axs2.plot(zgrid, defprior23[:,seddict[sed]]*multi, color=col, lw=2,ls='--', label=f\"hdfn prior {sed}\")\n",
+    "    axs2.plot(zgrid, newprior23[:,seddict[sed]]*multi, color=col, ls='-', label=f\"new prior {sed}\")\n",
+    "    axs2.set_title(\"priors for mag=23.0\")\n",
+    "    axs3.plot(zgrid, defprior25[:,seddict[sed]]*multi, color=col, lw=2,ls='--', label=f\"hdfn prior {sed}\")\n",
+    "    axs3.plot(zgrid, newprior25[:,seddict[sed]]*multi, color=col, ls='-', label=f\"new prior {sed}\")\n",
+    "    axs3.set_xlabel(\"redshift\")\n",
+    "    axs3.set_title(\"priors for mag=25.0\")\n",
+    "    axs3.set_ylabel(\"prior_probability\")\n",
+    "    axs.set_ylabel(\"prior probability\")\n",
+    "axs.legend(loc=\"upper right\", fontsize=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c18df01-72f2-45a4-aa29-84df8857f3f0",
+   "metadata": {},
+   "source": [
+    "at mag=20 our new prior predicts almost no Im/SB galaxies and more El and Sp, but otherwise the priors are not extremely different, which is probably a good thing.\n",
+    "\n",
+    "Finally, let's compute updated photo-z's with our new prior and new offsets and compare to the old ones:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82e273ae-af0d-41cc-90b0-ff053ab09b04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rerun_dict = dict(hdf5_groupname=\"photometry\", output=\"bpz_results_newprior.hdf5\",\n",
+    "                  bands=lsst_bands, err_bands=lsst_errs, filter_list=lsst_filts,\n",
+    "                  prior_band=\"mag_i_lsst\", no_prior=False,\n",
+    "                  override_file_offsets=False,\n",
+    "                  )\n",
+    "rerun_bpz = BPZliteEstimator.make_stage(name=\"bpz_def_prior\", model=\"./new_prior.pkl\", **rerun_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c66f98c1-9eb1-4853-a6db-436b77f4c713",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "final_res = rerun_bpz.estimate(test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9d64a18-5089-4a77-8eb6-84da16757f06",
+   "metadata": {},
+   "source": [
+    "Let's compare to our earlier, non-shifted and default prior results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fc0e4d5-8870-4608-bac0-a99e9d1dde36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fin_zmode = final_res().mode(grid=np.linspace(0,3,301)).flatten()\n",
+    "sz = test_data['photometry']['redshift']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de1eff90-56aa-4ad4-8d4c-70ecdba9e0d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def bias_sigiqr_outlier(sz, zb):\n",
+    "    ez = (zb - sz) / (1. + sz)\n",
+    "    bias = np.median(ez)\n",
+    "    x75, x25 = np.percentile(ez, [75.0, 25.0])\n",
+    "    iqr = x75 - x25\n",
+    "    sigma_iqr = iqr / 1.349\n",
+    "    outmask = np.fabs(ez) > 0.15\n",
+    "    fout = np.sum(outmask)/len(ez)\n",
+    "    return bias, sigma_iqr, fout\n",
+    "\n",
+    "bias, sigma, fout = bias_sigiqr_outlier(sz, zmode)\n",
+    "fin_bias, fin_sigma, fin_fout = bias_sigiqr_outlier(sz, fin_zmode)\n",
+    "\n",
+    "print(f\"bias with no shift: {bias}\\nsigma no shift: {sigma}\\nbias wshift/offsets: {fin_bias}\\nsigma wshift/offsets: {fin_sigma}\")\n",
+    "print(f\"outfrac no shift: {fout}\\noutfrac wshift/offset: {fin_fout}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1f8a9ea-5ecc-4d68-a70e-d76652d9067a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1, 2, figsize=(12, 6))\n",
+    "axs[0].scatter(sz, zmode, s=1, c='k')\n",
+    "axs[0].plot([0,3],[0,3], 'r--')\n",
+    "axs[1].scatter(sz, fin_zmode, s=1, c='k')\n",
+    "axs[1].plot([0,3],[0,3], 'r--')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b6f1ead-3a69-448c-af5c-40c87e2d0c35",
+   "metadata": {},
+   "source": [
+    "So, a reduction in the scatter, a slight increase in bias, and a reduction of the outlier rate, our prior and zero point tweaks helped, though we are still limited by our use of only 8 slightly mismatched SEDs that do not fully represent the underlying data. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b57e05-f3b8-44ed-b84f-13544a6f7d0f",
+   "metadata": {},
+   "source": [
+    "# Applying zero point shifts directly\n",
+    "\n",
+    "Finally, if you want to just apply zero point shifts directly that were determined from some other method, or re-using from other code, you do not need to read via the file, you can override the zero points from the model and apply directly by setting\n",
+    "`override_file_offsets=True` and then supplying an array of offsets (that is the same length as the number of filters/bands) with the `zp_offsets` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5630e6a-c6c5-4cef-8739-9290a57fc0c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forced_offsets = np.array([-0.0713074 , -0.1471,  0.0024,  0.0,  0.1883, -0.0486])\n",
+    "zp_dict = dict(hdf5_groupname=\"photometry\", output=\"bpz_results_newprior.hdf5\",\n",
+    "               bands=lsst_bands, err_bands=lsst_errs, filter_list=lsst_filts,\n",
+    "               prior_band=\"mag_i_lsst\", no_prior=False,\n",
+    "               override_file_offsets=True,\n",
+    "               zp_offsets=forced_offsets)\n",
+    "forced_bpz = BPZliteEstimator.make_stage(name=\"bpz_forced_offsets\", model=\"./new_prior.pkl\", **zp_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41480b0f-edb3-4b89-86be-af77521c23bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forced_res = forced_bpz.estimate(test_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8604c64b-fd35-4e23-9b8c-8faed4ecadfd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Addresses #219 adds a new demo notebook that demos stuff in the new BPZ PR

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
